### PR TITLE
Feat/add pokemon

### DIFF
--- a/app/Http/Controllers/PokemonController.php
+++ b/app/Http/Controllers/PokemonController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class PokemonController extends Controller
+{
+    //
+}

--- a/app/Http/Controllers/PokemonController.php
+++ b/app/Http/Controllers/PokemonController.php
@@ -3,8 +3,116 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use App\Pokemon;
 
 class PokemonController extends Controller
 {
-    //
+    public function index(Request $request)
+    {
+        // Get page number query parameter and convert to an int. If not provided, default to first page (1).
+        $page = (int)$request->input('page', 1);
+        // If the provided value was less than or equal to 0, fail. All non int inputs will have converted to 0.
+        if (0 >= $page)
+        {
+            // Return json response. Code 400 - Bad Request
+            return response()->json([
+                'success' => false,
+                'message' => 'The provided page number is not an acceptable value. '.
+                    'The page query parameter must be set an integer greater than or equal to 1.',
+                'links' => [
+                    'first' => "{$_ENV['APP_URL']}/api/pokemon?page=1"
+                ]
+                ], 400);
+        }
+
+        // Get count query parameter and convert to an int. If not provided, default to 10 items per page.
+        $count = (int)$request->input('count', 10);
+        // If the provided count is not 5, 10, 20, 25, 50, or 100 items per page. Fail.
+        if (!in_array($count, [5, 10, 20, 25, 50, 100]))
+        {
+            // Retturn json response. Code 400 - Bad Request
+            return response()->json([
+                'success' => false,
+                'message' => 'The provided page count is not an acceptable value. '.
+                    'Acceptable page counts are 5, 10, 20, 25, 50, and 100',
+                'links' => [
+                    '5Count' => "{$_ENV['APP_URL']}/api/pokemon?count=5",
+                    '10Count' => "{$_ENV['APP_URL']}/api/pokemon?count=10",
+                    '20Count' => "{$_ENV['APP_URL']}/api/pokemon?count=20",
+                    '25Count' => "{$_ENV['APP_URL']}/api/pokemon?count=25",
+                    '50Count' => "{$_ENV['APP_URL']}/api/pokemon?count=50",
+                    '100Count' => "{$_ENV['APP_URL']}/api/pokemon?count=100"
+                ]
+            ], 400);
+        };
+        
+        $pokemon = Pokemon::orderBy('id', 'asc')->get();
+
+        // If the page number/count provided would constitute a non existent page (greater than the range of pages for the count), fail.
+        if ($page > $last = (ceil($pokemon->count() / $count)))
+        {
+            // Return json response. Code 400 - Bad Request.
+            return response()->json([
+                'success' => false,
+                'message' => 'The provided page number does not exist for the provided page count. '.
+                    'The page number is greater than the last available page.',
+                'links' => [
+                    'last' => "{$_ENV['APP_URL']}/api/pokemon?page={$last}&count={$count}"
+                ]
+                ], 400);
+        }
+
+        // Try to retrieve the pokemon for the desired page. Catch any errors.
+        try {
+            // dd($pokemon);
+            $pokemon = array_slice(
+                $pokemon->all(), 
+                ($page-1)*$count, // '$page - 1' as the first page (1) would be offset 0 times, not offset once.
+                $count
+            );
+        } catch (Exception $e) {
+            // Return json response. Code 500 - Insernal Server Error.
+            return response()->json([
+                'success' => false,
+                'message' => 'Oops, something when wrong on our end.'
+            ], 500);
+        }
+
+        // Determine previous/next page. -1/+1 of current unless current is the first or last page.
+        $previous = ($page == 1 ? 1 : ($page - 1));
+        $next = ($page == $last ? $last : ($page + 1));
+
+        // Map pokemon array to only include the desired information. Add link to self's full information.
+        $pokemon = array_map(function($oldPokemon) {
+            return [
+                'id' => $oldPokemon->id,
+                'name' => $oldPokemon->name,
+                'types' => $oldPokemon->types,
+                'description' => $oldPokemon->description,
+                'links' => [
+                    'self' => "{$_ENV['APP_URL']}/api/pokemon/{$oldPokemon->id}"
+                ]
+                ];
+        }, $pokemon);
+
+        // Return json response. 200 - OK
+        return response()->json([
+            'success' => true,
+            'message' => "Page {$page} of the paginate list of pokemon defined with {$count} pokemon per page ".
+                "was successfully retrieved.",
+            'links' => [
+                'first' => "{$_ENV['APP_URL']}/api/pokemon?page=1&count={$count}",
+                'previous' => "{$_ENV['APP_URL']}/api/pokemon?page={$previous}&count={$count}",
+                'self' => "{$_ENV['APP_URL']}/api/pokemon?page={$page}&count={$count}",
+                'next' => "{$_ENV['APP_URL']}/api/pokemon?page={$next}&count={$count}",
+                'last' => "{$_ENV['APP_URL']}/api/pokemon?page={$last}&count={$count}",
+            ],
+            'data' => [
+                'page_number' => $page,
+                'total_pages' =>$last,
+                'count' => $count,
+                'pokemon' => $pokemon
+            ]
+        ], 200);
+    }
 }

--- a/app/Http/Controllers/PokemonController.php
+++ b/app/Http/Controllers/PokemonController.php
@@ -7,6 +7,10 @@ use App\Pokemon;
 
 class PokemonController extends Controller
 {
+    /**
+     * Retrieves the page (number) and count (per page) query parameters from the request and returns the desired page
+     * from a paginated list of pokemon that contains the desired count per page.
+     */
     public function index(Request $request)
     {
         // Get page number query parameter and convert to an int. If not provided, default to first page (1).
@@ -113,6 +117,39 @@ class PokemonController extends Controller
                 'count' => $count,
                 'pokemon' => $pokemon
             ]
+        ], 200);
+    }
+
+
+    /**
+     * Takes the provided $id parameter and returns the information for the
+     * pokemon with that id.
+     */
+    public function show($id)
+    {
+        // Query for a pokemon with the desired id.
+        $pokemon = Pokemon::where('id', $id)->first();
+
+        // If no pokemon is found, fail.
+        if (!$pokemon) {
+            // Return json response. 404 - Not Found
+            return response()->json([
+                'success' => false,
+                'message' => "Could not find a pokemon with the id {$id}.",
+                'links' => [
+                    'PokemonListPage1' => "{$_ENV['APP_URL']}/api/pokemon?page=1&count=10"
+                ]
+            ], 404);
+        }
+
+        // Else, return json response. 200 - OK
+        return response()->json([
+            'success' => true,
+            'message' => "Information for {$pokemon->name}, id = {$id}, successfully retrieved.",
+            'links' => [
+                'self' => "{$_ENV['APP_URL']}/api/pokemon/{$id}"
+            ],
+            'data' => $pokemon
         ], 200);
     }
 }

--- a/app/Pokemon.php
+++ b/app/Pokemon.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Pokemon extends Model
+{
+    //
+}

--- a/app/Pokemon.php
+++ b/app/Pokemon.php
@@ -6,5 +6,21 @@ use Illuminate\Database\Eloquent\Model;
 
 class Pokemon extends Model
 {
-    //
+    /**
+     * Causes the defined database fields (types, abilities, egg_groups, stats)
+     * to automatically cast from JSON to a php array when the are retrieved.
+     */
+    protected $casts = [
+        'types' => 'array',
+        'abilities' => 'array',
+        'egg_groups' => 'array',
+        'stats' => 'array',
+    ];
+
+    // Fillable fields.
+    protected $fillable = [
+        'id', 'name', 'types', 'height', 
+        'wieght', 'abilities', 'egg_groups', 
+        'states', 'genus', 'description'
+    ];
 }

--- a/database/data/pokemon.csv
+++ b/database/data/pokemon.csv
@@ -1,0 +1,1635 @@
+﻿id,"name","types","height","weight","abilities","egg_groups","stats","genus","description"
+1,"Bulbasaur","[""poison"", ""grass""]",7.00,69.00,"[""chlorophyll"", ""overgrow""]","[""plant"", ""monster""]","{""hp"": 45, ""speed"": 45, ""attack"": 49, ""defense"": 49, ""special-attack"": 65, ""special-defense"": 65}","Seed Pokémon","Bulbasaur can be seen napping in bright sunlight.
+There is a seed on its back. By soaking up the sun’s rays,
+the seed grows progressively larger."
+2,"Ivysaur","[""poison"", ""grass""]",10.00,130.00,"[""chlorophyll"", ""overgrow""]","[""plant"", ""monster""]","{""hp"": 60, ""speed"": 60, ""attack"": 62, ""defense"": 63, ""special-attack"": 80, ""special-defense"": 80}","Seed Pokémon","There is a bud on this Pokémon’s back. To support its weight,
+Ivysaur’s legs and trunk grow thick and strong.
+If it starts spending more time lying in the sunlight,
+it’s a sign that the bud will bloom into a large flower soon."
+3,"Venusaur","[""poison"", ""grass""]",20.00,1000.00,"[""chlorophyll"", ""overgrow""]","[""plant"", ""monster""]","{""hp"": 80, ""speed"": 80, ""attack"": 82, ""defense"": 83, ""special-attack"": 100, ""special-defense"": 100}","Seed Pokémon","There is a large flower on Venusaur’s back. The flower is said
+to take on vivid colors if it gets plenty of nutrition and sunlight.
+The flower’s aroma soothes the emotions of people."
+4,"Charmander","[""fire""]",6.00,85.00,"[""solar-power"", ""blaze""]","[""dragon"", ""monster""]","{""hp"": 39, ""speed"": 65, ""attack"": 52, ""defense"": 43, ""special-attack"": 60, ""special-defense"": 50}","Lizard Pokémon","The flame that burns at the tip of its tail is an indication
+of its emotions. The flame wavers when Charmander
+is enjoying itself. If the Pokémon becomes enraged,
+the flame burns fiercely."
+5,"Charmeleon","[""fire""]",11.00,190.00,"[""solar-power"", ""blaze""]","[""dragon"", ""monster""]","{""hp"": 58, ""speed"": 80, ""attack"": 64, ""defense"": 58, ""special-attack"": 80, ""special-defense"": 65}","Flame Pokémon","Charmeleon mercilessly destroys its foes using its sharp
+claws. If it encounters a strong foe, it turns aggressive.
+In this excited state, the flame at the tip of its tail flares with
+a bluish white color."
+6,"Charizard","[""flying"", ""fire""]",17.00,905.00,"[""solar-power"", ""blaze""]","[""dragon"", ""monster""]","{""hp"": 78, ""speed"": 100, ""attack"": 84, ""defense"": 78, ""special-attack"": 109, ""special-defense"": 85}","Flame Pokémon","Charizard flies around the sky in search of powerful opponents.
+It breathes fire of such great heat that it melts anything.
+However, it never turns its fiery breath on any opponent
+weaker than itself."
+7,"Squirtle","[""water""]",5.00,90.00,"[""rain-dish"", ""torrent""]","[""water1"", ""monster""]","{""hp"": 44, ""speed"": 43, ""attack"": 48, ""defense"": 65, ""special-attack"": 50, ""special-defense"": 64}","Tiny Turtle Pokémon","Squirtle’s shell is not merely used for protection.
+The shell’s rounded shape and the grooves on its
+surface help minimize resistance in water,
+enabling this Pokémon to swim at high speeds."
+8,"Wartortle","[""water""]",10.00,225.00,"[""rain-dish"", ""torrent""]","[""water1"", ""monster""]","{""hp"": 59, ""speed"": 58, ""attack"": 63, ""defense"": 80, ""special-attack"": 65, ""special-defense"": 80}","Turtle Pokémon","Its tail is large and covered with a rich, thick fur. The tail
+becomes increasingly deeper in color as Wartortle ages.
+The scratches on its shell are evidence of this Pokémon’s
+toughness as a battler."
+9,"Blastoise","[""water""]",16.00,855.00,"[""rain-dish"", ""torrent""]","[""water1"", ""monster""]","{""hp"": 79, ""speed"": 78, ""attack"": 83, ""defense"": 100, ""special-attack"": 85, ""special-defense"": 105}","Shellfish Pokémon","Blastoise has water spouts that protrude from its shell.
+The water spouts are very accurate.
+They can shoot bullets of water with enough accuracy
+to strike empty cans from a distance of over 160 feet."
+10,"Caterpie","[""bug""]",3.00,29.00,"[""run-away"", ""shield-dust""]","[""bug""]","{""hp"": 45, ""speed"": 45, ""attack"": 30, ""defense"": 35, ""special-attack"": 20, ""special-defense"": 20}","Worm Pokémon","It’s easy to catch, and it grows quickly, making
+it one of the top recommendations for novice
+Pokémon Trainers."
+11,"Metapod","[""bug""]",7.00,99.00,"[""shed-skin""]","[""bug""]","{""hp"": 50, ""speed"": 30, ""attack"": 20, ""defense"": 55, ""special-attack"": 25, ""special-defense"": 25}","Cocoon Pokémon","Its shell is hard, but it’s still just a bug shell.
+It’s been known to break, so intense battles
+with it should be avoided."
+12,"Butterfree","[""flying"", ""bug""]",11.00,320.00,"[""tinted-lens"", ""compound-eyes""]","[""bug""]","{""hp"": 60, ""speed"": 70, ""attack"": 45, ""defense"": 50, ""special-attack"": 90, ""special-defense"": 80}","Butterfly Pokémon","When attacked by other Pokémon, it defends
+itself by scattering its poisonous scales and
+fluttering its wings."
+13,"Weedle","[""poison"", ""bug""]",3.00,32.00,"[""run-away"", ""shield-dust""]","[""bug""]","{""hp"": 40, ""speed"": 50, ""attack"": 35, ""defense"": 30, ""special-attack"": 20, ""special-defense"": 20}","Hairy Bug Pokémon","Weedle has an extremely acute sense of smell. It is capable
+of distinguishing its favorite kinds of leaves from those it
+dislikes just by sniffing with its big red proboscis (nose)."
+14,"Kakuna","[""poison"", ""bug""]",6.00,100.00,"[""shed-skin""]","[""bug""]","{""hp"": 45, ""speed"": 35, ""attack"": 25, ""defense"": 50, ""special-attack"": 25, ""special-defense"": 25}","Cocoon Pokémon","Kakuna remains virtually immobile as it clings to a tree.
+However, on the inside, it is extremely busy as it prepares
+for its coming evolution.
+This is evident from how hot the shell becomes to the touch."
+15,"Beedrill","[""poison"", ""bug""]",10.00,295.00,"[""sniper"", ""swarm""]","[""bug""]","{""hp"": 65, ""speed"": 75, ""attack"": 90, ""defense"": 40, ""special-attack"": 45, ""special-defense"": 80}","Poison Bee Pokémon","Beedrill is extremely territorial. No one should ever approach
+its nest—this is for their own safety. If angered, they will attack
+in a furious swarm."
+16,"Pidgey","[""flying"", ""normal""]",3.00,18.00,"[""big-pecks"", ""tangled-feet"", ""keen-eye""]","[""flying""]","{""hp"": 40, ""speed"": 56, ""attack"": 45, ""defense"": 40, ""special-attack"": 35, ""special-defense"": 35}","Tiny Bird Pokémon","Pidgey has an extremely sharp sense of direction.
+It is capable of unerringly returning home to its nest,
+however far it may be removed from its familiar surroundings."
+17,"Pidgeotto","[""flying"", ""normal""]",11.00,300.00,"[""big-pecks"", ""tangled-feet"", ""keen-eye""]","[""flying""]","{""hp"": 63, ""speed"": 71, ""attack"": 60, ""defense"": 55, ""special-attack"": 50, ""special-defense"": 50}","Bird Pokémon","Pidgeotto claims a large area as its own territory. This
+Pokémon flies around, patrolling its living space. If its territory
+is violated, it shows no mercy in thoroughly punishing the foe
+with its sharp claws."
+18,"Pidgeot","[""flying"", ""normal""]",15.00,395.00,"[""big-pecks"", ""tangled-feet"", ""keen-eye""]","[""flying""]","{""hp"": 83, ""speed"": 101, ""attack"": 80, ""defense"": 75, ""special-attack"": 70, ""special-defense"": 70}","Bird Pokémon","This Pokémon has a dazzling plumage of beautifully
+glossy feathers. Many Trainers are captivated by the
+striking beauty of the feathers on its head, compelling
+them to choose Pidgeot as their Pokémon."
+19,"Rattata","[""normal""]",3.00,35.00,"[""hustle"", ""guts"", ""run-away""]","[""ground""]","{""hp"": 30, ""speed"": 72, ""attack"": 56, ""defense"": 35, ""special-attack"": 25, ""special-defense"": 35}","Mouse Pokémon","With their strong capacity for survival, they can
+live in dirty places without concern. Left
+unchecked, their numbers multiply rapidly."
+20,"Raticate","[""normal""]",7.00,185.00,"[""hustle"", ""guts"", ""run-away""]","[""ground""]","{""hp"": 55, ""speed"": 97, ""attack"": 81, ""defense"": 60, ""special-attack"": 50, ""special-defense"": 70}","Mouse Pokémon","Its disposition is far more violent than its looks
+would suggest. Don’t let your hand get too close
+to its face, as it could bite your hand clean off."
+21,"Spearow","[""flying"", ""normal""]",3.00,20.00,"[""sniper"", ""keen-eye""]","[""flying""]","{""hp"": 40, ""speed"": 70, ""attack"": 60, ""defense"": 30, ""special-attack"": 31, ""special-defense"": 31}","Tiny Bird Pokémon","Farmers whose fields are troubled by bug
+Pokémon appreciate Spearow for its vigorous
+appetite and look after it."
+22,"Fearow","[""flying"", ""normal""]",12.00,380.00,"[""sniper"", ""keen-eye""]","[""flying""]","{""hp"": 65, ""speed"": 100, ""attack"": 90, ""defense"": 65, ""special-attack"": 61, ""special-defense"": 61}","Beak Pokémon","Drawings of a Pokémon resembling Fearow can
+be seen in murals from deep in ancient history."
+23,"Ekans","[""poison""]",20.00,69.00,"[""unnerve"", ""shed-skin"", ""intimidate""]","[""dragon"", ""ground""]","{""hp"": 35, ""speed"": 55, ""attack"": 60, ""defense"": 44, ""special-attack"": 40, ""special-defense"": 54}","Snake Pokémon","Ekans curls itself up in a spiral while it rests. Assuming this
+position allows it to quickly respond to a threat from any
+direction with a glare from its upraised head."
+24,"Arbok","[""poison""]",35.00,650.00,"[""unnerve"", ""shed-skin"", ""intimidate""]","[""dragon"", ""ground""]","{""hp"": 60, ""speed"": 80, ""attack"": 95, ""defense"": 69, ""special-attack"": 65, ""special-defense"": 79}","Cobra Pokémon","This Pokémon is terrifically strong in order to constrict things
+with its body. It can even flatten steel oil drums. Once Arbok
+wraps its body around its foe, escaping its crunching embrace
+is impossible."
+25,"Pikachu","[""electric""]",4.00,60.00,"[""lightning-rod"", ""static""]","[""fairy"", ""ground""]","{""hp"": 35, ""speed"": 90, ""attack"": 55, ""defense"": 40, ""special-attack"": 50, ""special-defense"": 50}","Mouse Pokémon","It’s in its nature to store electricity. It feels
+stressed now and then if it’s unable to fully
+discharge the electricity."
+26,"Raichu","[""electric""]",8.00,300.00,"[""lightning-rod"", ""static""]","[""fairy"", ""ground""]","{""hp"": 60, ""speed"": 110, ""attack"": 90, ""defense"": 55, ""special-attack"": 90, ""special-defense"": 80}","Mouse Pokémon","It becomes aggressive when it has electricity
+stored up. At such times, even its Trainer has to
+take care to avoid being attacked."
+27,"Sandshrew","[""ground""]",6.00,120.00,"[""sand-rush"", ""sand-veil""]","[""ground""]","{""hp"": 50, ""speed"": 40, ""attack"": 75, ""defense"": 85, ""special-attack"": 20, ""special-defense"": 30}","Mouse Pokémon","It usually makes its home in deserts and arid
+zones, where rain does not fall. It digs holes to
+catch Bug-type Pokémon."
+28,"Sandslash","[""ground""]",10.00,295.00,"[""sand-rush"", ""sand-veil""]","[""ground""]","{""hp"": 75, ""speed"": 65, ""attack"": 100, ""defense"": 110, ""special-attack"": 45, ""special-defense"": 55}","Mouse Pokémon","It uses its claws to climb trees and then curls
+its body into a spiny ball, ready to drop onto
+any prey that appears."
+29,"Nidoran♀","[""poison""]",4.00,70.00,"[""hustle"", ""rivalry"", ""poison-point""]","[""ground"", ""monster""]","{""hp"": 55, ""speed"": 41, ""attack"": 47, ""defense"": 52, ""special-attack"": 40, ""special-defense"": 40}","Poison Pin Pokémon","Nidoran♀ has barbs that secrete a powerful poison.
+They are thought to have developed as protection for
+this small-bodied Pokémon. When enraged, it releases
+a horrible toxin from its horn."
+30,"Nidorina","[""poison""]",8.00,200.00,"[""hustle"", ""rivalry"", ""poison-point""]","[""no-eggs""]","{""hp"": 70, ""speed"": 56, ""attack"": 62, ""defense"": 67, ""special-attack"": 55, ""special-defense"": 55}","Poison Pin Pokémon","When Nidorina are with their friends or family, they keep
+their barbs tucked away to prevent hurting each other.
+This Pokémon appears to become nervous if separated
+from the others."
+31,"Nidoqueen","[""ground"", ""poison""]",13.00,600.00,"[""sheer-force"", ""rivalry"", ""poison-point""]","[""no-eggs""]","{""hp"": 90, ""speed"": 76, ""attack"": 92, ""defense"": 87, ""special-attack"": 75, ""special-defense"": 85}","Drill Pokémon","Nidoqueen’s body is encased in extremely hard scales.
+It is adept at sending foes flying with harsh tackles. This
+Pokémon is at its strongest when it is defending its young."
+32,"Nidoran♂","[""poison""]",5.00,90.00,"[""hustle"", ""rivalry"", ""poison-point""]","[""ground"", ""monster""]","{""hp"": 46, ""speed"": 50, ""attack"": 57, ""defense"": 40, ""special-attack"": 40, ""special-defense"": 40}","Poison Pin Pokémon","Nidoran♂ has developed muscles for moving its ears. Thanks
+to them, the ears can be freely moved in any direction. Even
+the slightest sound does not escape this Pokémon’s notice."
+33,"Nidorino","[""poison""]",9.00,195.00,"[""hustle"", ""rivalry"", ""poison-point""]","[""ground"", ""monster""]","{""hp"": 61, ""speed"": 65, ""attack"": 72, ""defense"": 57, ""special-attack"": 55, ""special-defense"": 55}","Poison Pin Pokémon","Nidorino has a horn that is harder than a diamond. If it senses
+a hostile presence, all the barbs on its back bristle up at once,
+and it challenges the foe with all its might."
+34,"Nidoking","[""ground"", ""poison""]",14.00,620.00,"[""sheer-force"", ""rivalry"", ""poison-point""]","[""ground"", ""monster""]","{""hp"": 81, ""speed"": 85, ""attack"": 102, ""defense"": 77, ""special-attack"": 85, ""special-defense"": 75}","Drill Pokémon","Nidoking’s thick tail packs enormously destructive power.
+With one swing, it can topple a metal transmission tower. Once
+this Pokémon goes on a rampage, there is no stopping it."
+35,"Clefairy","[""fairy""]",6.00,75.00,"[""friend-guard"", ""magic-guard"", ""cute-charm""]","[""fairy""]","{""hp"": 70, ""speed"": 35, ""attack"": 45, ""defense"": 48, ""special-attack"": 60, ""special-defense"": 65}","Fairy Pokémon","On nights with a full moon, they gather together
+and dance. The surrounding area is enveloped
+in an abnormal magnetic field."
+36,"Clefable","[""fairy""]",13.00,400.00,"[""unaware"", ""magic-guard"", ""cute-charm""]","[""fairy""]","{""hp"": 95, ""speed"": 60, ""attack"": 70, ""defense"": 73, ""special-attack"": 95, ""special-defense"": 90}","Fairy Pokémon","According to tradition, people who see a pair
+of Clefable skipping by can look forward to a
+happy marriage."
+37,"Vulpix","[""fire""]",6.00,99.00,"[""drought"", ""flash-fire""]","[""ground""]","{""hp"": 38, ""speed"": 65, ""attack"": 41, ""defense"": 40, ""special-attack"": 50, ""special-defense"": 65}","Fox Pokémon","From its mouth spew flames that seem to
+resemble the spirits of the deceased. Some
+people mistakenly think this fire is a ghost."
+38,"Ninetales","[""fire""]",11.00,199.00,"[""drought"", ""flash-fire""]","[""ground""]","{""hp"": 73, ""speed"": 100, ""attack"": 76, ""defense"": 75, ""special-attack"": 81, ""special-defense"": 100}","Fox Pokémon","Said to live for a thousand years, this Pokémon
+uses its supernatural abilities to manipulate fire.
+It can burn its prey to a crisp as it pleases."
+39,"Jigglypuff","[""fairy"", ""normal""]",5.00,55.00,"[""friend-guard"", ""competitive"", ""cute-charm""]","[""fairy""]","{""hp"": 115, ""speed"": 20, ""attack"": 45, ""defense"": 20, ""special-attack"": 45, ""special-defense"": 25}","Balloon Pokémon","Jigglypuff possess a vocal range that exceeds
+12 octaves, but each individual’s singing skill
+depends on its own effort."
+40,"Wigglytuff","[""fairy"", ""normal""]",10.00,120.00,"[""frisk"", ""competitive"", ""cute-charm""]","[""fairy""]","{""hp"": 140, ""speed"": 45, ""attack"": 70, ""defense"": 45, ""special-attack"": 85, ""special-defense"": 50}","Balloon Pokémon","As it inhales, it expands...and expands...and
+expands. Wigglytuff compete to see which one
+can inflate itself the most."
+41,"Zubat","[""flying"", ""poison""]",8.00,75.00,"[""infiltrator"", ""inner-focus""]","[""flying""]","{""hp"": 40, ""speed"": 55, ""attack"": 45, ""defense"": 35, ""special-attack"": 30, ""special-defense"": 40}","Bat Pokémon","When exposed to sunlight, they suffer burns.
+The frequency of their ultrasonic waves can
+differ slightly from colony to colony."
+42,"Golbat","[""flying"", ""poison""]",16.00,550.00,"[""infiltrator"", ""inner-focus""]","[""flying""]","{""hp"": 75, ""speed"": 90, ""attack"": 80, ""defense"": 70, ""special-attack"": 65, ""special-defense"": 75}","Bat Pokémon","Sometimes they drink so much blood, they can’t
+fly anymore. Then they fall to the ground and
+become food for other Pokémon."
+43,"Oddish","[""poison"", ""grass""]",5.00,54.00,"[""run-away"", ""chlorophyll""]","[""plant""]","{""hp"": 45, ""speed"": 30, ""attack"": 50, ""defense"": 55, ""special-attack"": 75, ""special-defense"": 65}","Weed Pokémon","Oddish searches for fertile, nutrient-rich soil, then plants itself.
+During the daytime, while it is planted, this Pokémon’s feet
+are thought to change shape and become similar to the roots
+of trees."
+44,"Gloom","[""poison"", ""grass""]",8.00,86.00,"[""stench"", ""chlorophyll""]","[""plant""]","{""hp"": 60, ""speed"": 40, ""attack"": 65, ""defense"": 70, ""special-attack"": 85, ""special-defense"": 75}","Weed Pokémon","From its mouth Gloom drips honey that smells absolutely
+horrible. Apparently, it loves the horrid stench. It sniffs the
+noxious fumes and then drools even more of its honey."
+45,"Vileplume","[""poison"", ""grass""]",12.00,186.00,"[""effect-spore"", ""chlorophyll""]","[""plant""]","{""hp"": 75, ""speed"": 50, ""attack"": 80, ""defense"": 85, ""special-attack"": 110, ""special-defense"": 90}","Flower Pokémon","Vileplume has the world’s largest petals. They are used to
+attract prey that are then doused with toxic spores. Once the
+prey are immobilized, this Pokémon catches and devours them."
+46,"Paras","[""grass"", ""bug""]",3.00,54.00,"[""damp"", ""dry-skin"", ""effect-spore""]","[""plant"", ""bug""]","{""hp"": 35, ""speed"": 25, ""attack"": 70, ""defense"": 55, ""special-attack"": 45, ""special-defense"": 55}","Mushroom Pokémon","Mushrooms called tochukaso sprout from its
+back. They can be dried and powdered to make
+a medicine used to extend life."
+47,"Parasect","[""grass"", ""bug""]",10.00,295.00,"[""damp"", ""dry-skin"", ""effect-spore""]","[""plant"", ""bug""]","{""hp"": 60, ""speed"": 30, ""attack"": 95, ""defense"": 80, ""special-attack"": 60, ""special-defense"": 80}","Mushroom Pokémon","It scatters toxic spores from its mushroom cap.
+Once harvested, these spores can be steeped
+and boiled down to prepare herbal medicines."
+48,"Venonat","[""poison"", ""bug""]",10.00,300.00,"[""run-away"", ""tinted-lens"", ""compound-eyes""]","[""bug""]","{""hp"": 60, ""speed"": 45, ""attack"": 55, ""defense"": 50, ""special-attack"": 40, ""special-defense"": 55}","Insect Pokémon","Venonat is said to have evolved with a coat of thin, stiff hair
+that covers its entire body for protection. It possesses large
+eyes that never fail to spot even minuscule prey."
+49,"Venomoth","[""poison"", ""bug""]",15.00,125.00,"[""wonder-skin"", ""tinted-lens"", ""shield-dust""]","[""bug""]","{""hp"": 70, ""speed"": 90, ""attack"": 65, ""defense"": 60, ""special-attack"": 90, ""special-defense"": 75}","Poison Moth Pokémon","Venomoth is nocturnal—it is a Pokémon that only becomes
+active at night. Its favorite prey are small insects that gather
+around streetlights, attracted by the light in the darkness."
+50,"Diglett","[""ground""]",2.00,8.00,"[""sand-force"", ""arena-trap"", ""sand-veil""]","[""ground""]","{""hp"": 10, ""speed"": 95, ""attack"": 55, ""defense"": 25, ""special-attack"": 35, ""special-defense"": 45}","Mole Pokémon","Many farmers cherish and nurture Diglett
+because its droppings enrich the soil it lives in."
+51,"Dugtrio","[""ground""]",7.00,333.00,"[""sand-force"", ""arena-trap"", ""sand-veil""]","[""ground""]","{""hp"": 35, ""speed"": 120, ""attack"": 100, ""defense"": 50, ""special-attack"": 50, ""special-defense"": 70}","Mole Pokémon","Despite the closeness between this Pokémon
+and farmers and other people, no one has ever
+seen the parts of it concealed underground."
+52,"Meowth","[""normal""]",4.00,42.00,"[""unnerve"", ""technician"", ""pickup""]","[""ground""]","{""hp"": 40, ""speed"": 90, ""attack"": 45, ""defense"": 35, ""special-attack"": 40, ""special-defense"": 40}","Scratch Cat Pokémon","It loves shiny things. It often fights with
+Murkrow over prey they’re both trying to catch."
+53,"Persian","[""normal""]",10.00,320.00,"[""unnerve"", ""technician"", ""limber""]","[""ground""]","{""hp"": 65, ""speed"": 115, ""attack"": 70, ""defense"": 60, ""special-attack"": 65, ""special-defense"": 65}","Classy Cat Pokémon","It has a high opinion of itself, although not to
+the same extent as the Alolan Persian. It’s quite
+difficult to make friends with this Pokémon."
+54,"Psyduck","[""water""]",8.00,196.00,"[""swift-swim"", ""cloud-nine"", ""damp""]","[""ground"", ""water1""]","{""hp"": 50, ""speed"": 55, ""attack"": 52, ""defense"": 48, ""special-attack"": 65, ""special-defense"": 50}","Duck Pokémon","This Pokémon is troubled by constant
+headaches. The more pain it’s in, the more
+powerful its psychokinesis becomes."
+55,"Golduck","[""water""]",17.00,766.00,"[""swift-swim"", ""cloud-nine"", ""damp""]","[""ground"", ""water1""]","{""hp"": 80, ""speed"": 85, ""attack"": 82, ""defense"": 78, ""special-attack"": 95, ""special-defense"": 80}","Duck Pokémon","It swims along the banks of lakes and catches
+fish Pokémon. It takes them to the shore and
+quietly eats them up."
+56,"Mankey","[""fighting""]",5.00,280.00,"[""defiant"", ""anger-point"", ""vital-spirit""]","[""ground""]","{""hp"": 40, ""speed"": 70, ""attack"": 80, ""defense"": 35, ""special-attack"": 35, ""special-defense"": 45}","Pig Monkey Pokémon","Its raging tires it out and causes it to fall asleep,
+but the anger resonating in its dreams causes it
+to wake up—which infuriates it all over again."
+57,"Primeape","[""fighting""]",10.00,320.00,"[""defiant"", ""anger-point"", ""vital-spirit""]","[""ground""]","{""hp"": 65, ""speed"": 95, ""attack"": 105, ""defense"": 60, ""special-attack"": 60, ""special-defense"": 70}","Pig Monkey Pokémon","Some researchers theorize that Primeape
+remains angry even when inside a Poké Ball."
+58,"Growlithe","[""fire""]",7.00,190.00,"[""justified"", ""flash-fire"", ""intimidate""]","[""ground""]","{""hp"": 55, ""speed"": 60, ""attack"": 70, ""defense"": 45, ""special-attack"": 70, ""special-defense"": 50}","Puppy Pokémon","It looks cute, but when you approach another
+Trainer’s Growlithe, it will bark at you and bite."
+59,"Arcanine","[""fire""]",19.00,1550.00,"[""justified"", ""flash-fire"", ""intimidate""]","[""ground""]","{""hp"": 90, ""speed"": 95, ""attack"": 110, ""defense"": 80, ""special-attack"": 100, ""special-defense"": 80}","Legendary Pokémon","The fire burning inside its body serves as the
+energy to fuel it as it runs great distances.
+It appears in many legends."
+60,"Poliwag","[""water""]",6.00,124.00,"[""swift-swim"", ""damp"", ""water-absorb""]","[""water1""]","{""hp"": 40, ""speed"": 90, ""attack"": 50, ""defense"": 40, ""special-attack"": 40, ""special-defense"": 40}","Tadpole Pokémon","It’s still not very good at walking. Its Trainers
+should train this Pokémon to walk every day."
+61,"Poliwhirl","[""water""]",10.00,200.00,"[""swift-swim"", ""damp"", ""water-absorb""]","[""water1""]","{""hp"": 65, ""speed"": 90, ""attack"": 65, ""defense"": 65, ""special-attack"": 50, ""special-defense"": 50}","Tadpole Pokémon","It marches over the land in search of bug
+Pokémon to eat. Then it takes them underwater
+so it can dine on them where it’s safe."
+62,"Poliwrath","[""fighting"", ""water""]",13.00,540.00,"[""swift-swim"", ""damp"", ""water-absorb""]","[""water1""]","{""hp"": 90, ""speed"": 70, ""attack"": 95, ""defense"": 95, ""special-attack"": 70, ""special-defense"": 90}","Tadpole Pokémon","Its percentage of body fat is nearly zero. Its
+body is entirely muscle, which makes it heavy
+and forces its swimming prowess to develop."
+63,"Abra","[""psychic""]",9.00,195.00,"[""magic-guard"", ""inner-focus"", ""synchronize""]","[""humanshape""]","{""hp"": 25, ""speed"": 90, ""attack"": 20, ""defense"": 15, ""special-attack"": 105, ""special-defense"": 55}","Psi Pokémon","It can teleport itself to safety while it’s asleep,
+but when it wakes, it doesn’t know where it is,
+so it panics."
+64,"Kadabra","[""psychic""]",13.00,565.00,"[""magic-guard"", ""inner-focus"", ""synchronize""]","[""humanshape""]","{""hp"": 40, ""speed"": 105, ""attack"": 35, ""defense"": 30, ""special-attack"": 120, ""special-defense"": 70}","Psi Pokémon","Kadabra’s presence infests televisions and
+monitors with creepy shadows that bring
+bad luck."
+65,"Alakazam","[""psychic""]",15.00,480.00,"[""magic-guard"", ""inner-focus"", ""synchronize""]","[""humanshape""]","{""hp"": 55, ""speed"": 120, ""attack"": 50, ""defense"": 45, ""special-attack"": 135, ""special-defense"": 95}","Psi Pokémon","Its brain cells continue to increase in number
+until its death. The older the Alakazam, the
+larger its head."
+66,"Machop","[""fighting""]",8.00,195.00,"[""steadfast"", ""no-guard"", ""guts""]","[""humanshape""]","{""hp"": 70, ""speed"": 35, ""attack"": 80, ""defense"": 50, ""special-attack"": 35, ""special-defense"": 35}","Superpower Pokémon","With its superhuman strength, it’s able to throw
+a hundred people all at the same time. Its
+strength comes from lifting Graveler every day."
+67,"Machoke","[""fighting""]",15.00,705.00,"[""steadfast"", ""no-guard"", ""guts""]","[""humanshape""]","{""hp"": 80, ""speed"": 45, ""attack"": 100, ""defense"": 70, ""special-attack"": 50, ""special-defense"": 60}","Superpower Pokémon","It willingly assists with hard labor because it
+knows the work is good training for its muscles."
+68,"Machamp","[""fighting""]",16.00,1300.00,"[""steadfast"", ""no-guard"", ""guts""]","[""humanshape""]","{""hp"": 90, ""speed"": 55, ""attack"": 130, ""defense"": 80, ""special-attack"": 65, ""special-defense"": 85}","Superpower Pokémon","It can lift heavy loads with the greatest of ease.
+It can even heft dump trucks. But its clumsy
+fingers prevent it from doing any precision work."
+69,"Bellsprout","[""poison"", ""grass""]",7.00,40.00,"[""gluttony"", ""chlorophyll""]","[""plant""]","{""hp"": 50, ""speed"": 40, ""attack"": 75, ""defense"": 35, ""special-attack"": 70, ""special-defense"": 30}","Flower Pokémon","Bellsprout’s thin and flexible body lets it bend and sway
+to avoid any attack, however strong it may be. From its mouth,
+this Pokémon spits a corrosive fluid that melts even iron."
+70,"Weepinbell","[""poison"", ""grass""]",10.00,64.00,"[""gluttony"", ""chlorophyll""]","[""plant""]","{""hp"": 65, ""speed"": 55, ""attack"": 90, ""defense"": 50, ""special-attack"": 85, ""special-defense"": 45}","Flycatcher Pokémon","Weepinbell has a large hook on its rear end. At night, the
+Pokémon hooks on to a tree branch and goes to sleep.
+If it moves around in its sleep, it may wake up to find itself
+on the ground."
+71,"Victreebel","[""poison"", ""grass""]",17.00,155.00,"[""gluttony"", ""chlorophyll""]","[""plant""]","{""hp"": 80, ""speed"": 70, ""attack"": 105, ""defense"": 65, ""special-attack"": 100, ""special-defense"": 70}","Flycatcher Pokémon","Victreebel has a long vine that extends from its head.
+This vine is waved and flicked about as if it were an animal
+to attract prey. When an unsuspecting prey draws near,
+this Pokémon swallows it whole."
+72,"Tentacool","[""poison"", ""water""]",9.00,455.00,"[""rain-dish"", ""liquid-ooze"", ""clear-body""]","[""water3""]","{""hp"": 40, ""speed"": 70, ""attack"": 40, ""defense"": 35, ""special-attack"": 50, ""special-defense"": 100}","Jellyfish Pokémon","It drifts in shallow seas, such as the areas near
+beaches. If you get bitten or stabbed by its
+toxic tentacles, rush to the hospital."
+73,"Tentacruel","[""poison"", ""water""]",16.00,550.00,"[""rain-dish"", ""liquid-ooze"", ""clear-body""]","[""water3""]","{""hp"": 80, ""speed"": 100, ""attack"": 70, ""defense"": 65, ""special-attack"": 80, ""special-defense"": 120}","Jellyfish Pokémon","Although these Pokémon are rare, when a large
+outbreak of them occurs, all fish Pokémon
+disappear from the surrounding sea."
+74,"Geodude","[""ground"", ""rock""]",4.00,200.00,"[""sand-veil"", ""sturdy"", ""rock-head""]","[""mineral""]","{""hp"": 40, ""speed"": 20, ""attack"": 80, ""defense"": 100, ""special-attack"": 30, ""special-defense"": 30}","Rock Pokémon","There are plenty of them to be found along any
+road. A scholar with too much free time once
+counted a hundred of them along a single route."
+75,"Graveler","[""ground"", ""rock""]",10.00,1050.00,"[""sand-veil"", ""sturdy"", ""rock-head""]","[""mineral""]","{""hp"": 55, ""speed"": 35, ""attack"": 95, ""defense"": 115, ""special-attack"": 45, ""special-defense"": 45}","Rock Pokémon","This slow-footed Pokémon moves by curling up
+and rolling instead of walking. With enough
+momentum, its speed can exceed 60 mph."
+76,"Golem","[""ground"", ""rock""]",14.00,3000.00,"[""sand-veil"", ""sturdy"", ""rock-head""]","[""mineral""]","{""hp"": 80, ""speed"": 45, ""attack"": 120, ""defense"": 130, ""special-attack"": 55, ""special-defense"": 65}","Megaton Pokémon","Once a year, this Pokémon molts, and its shed
+shell returns to the soil. This process creates
+enriched soil, so farmers collect the shells."
+77,"Ponyta","[""fire""]",10.00,300.00,"[""flame-body"", ""flash-fire"", ""run-away""]","[""ground""]","{""hp"": 50, ""speed"": 90, ""attack"": 85, ""defense"": 55, ""special-attack"": 65, ""special-defense"": 65}","Fire Horse Pokémon","Ponyta is very weak at birth. It can barely stand up.
+This Pokémon becomes stronger by stumbling and
+falling to keep up with its parent."
+78,"Rapidash","[""fire""]",17.00,950.00,"[""flame-body"", ""flash-fire"", ""run-away""]","[""ground""]","{""hp"": 65, ""speed"": 105, ""attack"": 100, ""defense"": 70, ""special-attack"": 80, ""special-defense"": 80}","Fire Horse Pokémon","Rapidash usually can be seen casually cantering in the fields
+and plains. However, when this Pokémon turns serious, its
+fiery manes flare and blaze as it gallops its way up to 150 mph."
+79,"Slowpoke","[""psychic"", ""water""]",12.00,360.00,"[""regenerator"", ""own-tempo"", ""oblivious""]","[""water1"", ""monster""]","{""hp"": 90, ""speed"": 15, ""attack"": 65, ""defense"": 65, ""special-attack"": 40, ""special-defense"": 40}","Dopey Pokémon","Alolan home cooking involves drying Slowpoke
+tails and then simmering them into a salty stew."
+80,"Slowbro","[""psychic"", ""water""]",16.00,785.00,"[""regenerator"", ""own-tempo"", ""oblivious""]","[""water1"", ""monster""]","{""hp"": 95, ""speed"": 30, ""attack"": 75, ""defense"": 110, ""special-attack"": 100, ""special-defense"": 80}","Hermit Crab Pokémon","Whenever Shellder bites down hard on its tail,
+it gives Slowbro a flash of inspiration...which it
+forgets a moment later."
+81,"Magnemite","[""steel"", ""electric""]",3.00,60.00,"[""analytic"", ""sturdy"", ""magnet-pull""]","[""mineral""]","{""hp"": 25, ""speed"": 45, ""attack"": 35, ""defense"": 70, ""special-attack"": 95, ""special-defense"": 55}","Magnet Pokémon","It sends out electromagnetic waves, which let it
+float through the air. Touching it while it’s eating
+electricity will give you a full-body shock."
+82,"Magneton","[""steel"", ""electric""]",10.00,600.00,"[""analytic"", ""sturdy"", ""magnet-pull""]","[""mineral""]","{""hp"": 50, ""speed"": 70, ""attack"": 60, ""defense"": 95, ""special-attack"": 120, ""special-defense"": 70}","Magnet Pokémon","It has about three times the electrical power of
+Magnemite. For some reason, outbreaks of this
+Pokémon happen when lots of sunspots appear."
+83,"Farfetch’d","[""flying"", ""normal""]",8.00,150.00,"[""defiant"", ""inner-focus"", ""keen-eye""]","[""ground"", ""flying""]","{""hp"": 52, ""speed"": 60, ""attack"": 90, ""defense"": 55, ""special-attack"": 58, ""special-defense"": 62}","Wild Duck Pokémon","Farfetch’d is always seen with a stalk from a plant of some
+sort. Apparently, there are good stalks and bad stalks. This
+Pokémon has been known to fight with others over stalks."
+84,"Doduo","[""flying"", ""normal""]",14.00,392.00,"[""tangled-feet"", ""early-bird"", ""run-away""]","[""flying""]","{""hp"": 35, ""speed"": 75, ""attack"": 85, ""defense"": 45, ""special-attack"": 35, ""special-defense"": 35}","Twin Bird Pokémon","Doduo’s two heads contain completely identical brains. A
+scientific study reported that on rare occasions, there will be
+examples of this Pokémon possessing different sets of brains."
+85,"Dodrio","[""flying"", ""normal""]",18.00,852.00,"[""tangled-feet"", ""early-bird"", ""run-away""]","[""flying""]","{""hp"": 60, ""speed"": 110, ""attack"": 110, ""defense"": 70, ""special-attack"": 60, ""special-defense"": 60}","Triple Bird Pokémon","Apparently, the heads aren’t the only parts of the body that
+Dodrio has three of. It has three sets of hearts and lungs as
+well, so it is capable of running long distances without rest."
+86,"Seel","[""water""]",11.00,900.00,"[""ice-body"", ""hydration"", ""thick-fat""]","[""ground"", ""water1""]","{""hp"": 65, ""speed"": 45, ""attack"": 45, ""defense"": 55, ""special-attack"": 45, ""special-defense"": 70}","Sea Lion Pokémon","Seel hunts for prey in the frigid sea underneath sheets of ice.
+When it needs to breathe, it punches a hole through the ice
+with the sharply protruding section of its head."
+87,"Dewgong","[""ice"", ""water""]",17.00,1200.00,"[""ice-body"", ""hydration"", ""thick-fat""]","[""ground"", ""water1""]","{""hp"": 90, ""speed"": 70, ""attack"": 70, ""defense"": 80, ""special-attack"": 70, ""special-defense"": 95}","Sea Lion Pokémon","Dewgong loves to snooze on bitterly cold ice. The sight of
+this Pokémon sleeping on a glacier was mistakenly thought
+to be a mermaid by a mariner long ago."
+88,"Grimer","[""poison""]",9.00,300.00,"[""poison-touch"", ""sticky-hold"", ""stench""]","[""indeterminate""]","{""hp"": 80, ""speed"": 25, ""attack"": 80, ""defense"": 50, ""special-attack"": 40, ""special-defense"": 50}","Sludge Pokémon","It was born from sludge transformed by
+exposure to X-rays from the moon. When its
+internal load of germs decreases, it dies."
+89,"Muk","[""poison""]",12.00,300.00,"[""poison-touch"", ""sticky-hold"", ""stench""]","[""indeterminate""]","{""hp"": 105, ""speed"": 50, ""attack"": 105, ""defense"": 75, ""special-attack"": 65, ""special-defense"": 100}","Sludge Pokémon","After recent environmental improvements, this
+Pokémon is now hardly seen at all. People
+speculate that it may go extinct at some point."
+90,"Shellder","[""water""]",3.00,40.00,"[""overcoat"", ""skill-link"", ""shell-armor""]","[""water3""]","{""hp"": 30, ""speed"": 40, ""attack"": 65, ""defense"": 100, ""special-attack"": 45, ""special-defense"": 25}","Bivalve Pokémon","This Pokémon’s tongue is always hanging out.
+It uses its tongue with great dexterity to dig up
+sand from the seabed in its search for food."
+91,"Cloyster","[""ice"", ""water""]",15.00,1325.00,"[""overcoat"", ""skill-link"", ""shell-armor""]","[""water3""]","{""hp"": 50, ""speed"": 70, ""attack"": 95, ""defense"": 180, ""special-attack"": 85, ""special-defense"": 45}","Bivalve Pokémon","Excavation of the tombs of ancient hunting
+tribes has turned up many spears tipped with
+spikes that had fallen off this Pokémon’s shell."
+92,"Gastly","[""poison"", ""ghost""]",13.00,1.00,"[""levitate""]","[""indeterminate""]","{""hp"": 30, ""speed"": 80, ""attack"": 35, ""defense"": 30, ""special-attack"": 100, ""special-defense"": 35}","Gas Pokémon","Although Gastly is barely visible, when it’s near,
+a faint sweet smell lingers."
+93,"Haunter","[""poison"", ""ghost""]",16.00,1.00,"[""levitate""]","[""indeterminate""]","{""hp"": 45, ""speed"": 95, ""attack"": 50, ""defense"": 45, ""special-attack"": 115, ""special-defense"": 55}","Gas Pokémon","It fears the light and revels in the dark. It may
+be on the verge of extinction in cities that stay
+brightly lit at night."
+94,"Gengar","[""poison"", ""ghost""]",15.00,405.00,"[""cursed-body""]","[""indeterminate""]","{""hp"": 60, ""speed"": 110, ""attack"": 65, ""defense"": 60, ""special-attack"": 130, ""special-defense"": 75}","Shadow Pokémon","It apparently wishes for a traveling companion.
+Since it was once human itself, it tries to create
+one by taking the lives of other humans."
+95,"Onix","[""ground"", ""rock""]",88.00,2100.00,"[""weak-armor"", ""sturdy"", ""rock-head""]","[""mineral""]","{""hp"": 35, ""speed"": 70, ""attack"": 45, ""defense"": 160, ""special-attack"": 30, ""special-defense"": 45}","Rock Snake Pokémon","Onix has a magnet in its brain. It acts as a compass so that
+this Pokémon does not lose direction while it is tunneling.
+As it grows older, its body becomes increasingly rounder
+and smoother."
+96,"Drowzee","[""psychic""]",10.00,324.00,"[""inner-focus"", ""forewarn"", ""insomnia""]","[""humanshape""]","{""hp"": 60, ""speed"": 42, ""attack"": 48, ""defense"": 45, ""special-attack"": 43, ""special-defense"": 90}","Hypnosis Pokémon","It finds really fun dreams tasty. When it makes
+friends with people, it may show them the most
+delicious dreams it’s ever eaten."
+97,"Hypno","[""psychic""]",16.00,756.00,"[""inner-focus"", ""forewarn"", ""insomnia""]","[""humanshape""]","{""hp"": 85, ""speed"": 67, ""attack"": 73, ""defense"": 70, ""special-attack"": 73, ""special-defense"": 115}","Hypnosis Pokémon","As a matter of course, it makes anyone it meets
+fall asleep and has a taste of their dreams.
+Anyone having a good dream, it carries off."
+98,"Krabby","[""water""]",4.00,65.00,"[""sheer-force"", ""shell-armor"", ""hyper-cutter""]","[""water3""]","{""hp"": 30, ""speed"": 50, ""attack"": 105, ""defense"": 90, ""special-attack"": 25, ""special-defense"": 25}","River Crab Pokémon","Krabby live on beaches, burrowed inside holes dug into
+the sand. On sandy beaches with little in the way of food,
+these Pokémon can be seen squabbling with each other
+over territory."
+99,"Kingler","[""water""]",13.00,600.00,"[""sheer-force"", ""shell-armor"", ""hyper-cutter""]","[""water3""]","{""hp"": 55, ""speed"": 75, ""attack"": 130, ""defense"": 115, ""special-attack"": 50, ""special-defense"": 50}","Pincer Pokémon","Kingler has an enormous, oversized claw. It waves this huge
+claw in the air to communicate with others. However, because
+the claw is so heavy, the Pokémon quickly tires."
+100,"Voltorb","[""electric""]",5.00,104.00,"[""aftermath"", ""static"", ""soundproof""]","[""mineral""]","{""hp"": 40, ""speed"": 100, ""attack"": 30, ""defense"": 50, ""special-attack"": 55, ""special-defense"": 55}","Ball Pokémon","Voltorb is extremely sensitive—it explodes at the slightest
+of shocks. It is rumored that it was first created when a
+Poké Ball was exposed to a powerful pulse of energy."
+101,"Electrode","[""electric""]",12.00,666.00,"[""aftermath"", ""static"", ""soundproof""]","[""mineral""]","{""hp"": 60, ""speed"": 150, ""attack"": 50, ""defense"": 70, ""special-attack"": 80, ""special-defense"": 80}","Ball Pokémon","One of Electrode’s characteristics is its attraction to electricity.
+It is a problematical Pokémon that congregates mostly at
+electrical power plants to feed on electricity that has just
+been generated."
+102,"Exeggcute","[""psychic"", ""grass""]",4.00,25.00,"[""harvest"", ""chlorophyll""]","[""plant""]","{""hp"": 60, ""speed"": 40, ""attack"": 40, ""defense"": 80, ""special-attack"": 60, ""special-defense"": 45}","Egg Pokémon","Six of them together form a full-fledged
+Pokémon. It’s often hunted by Crabrawler,
+but uses psychokinesis to drive it off."
+103,"Exeggutor","[""psychic"", ""grass""]",20.00,1200.00,"[""harvest"", ""chlorophyll""]","[""plant""]","{""hp"": 95, ""speed"": 55, ""attack"": 95, ""defense"": 85, ""special-attack"": 125, ""special-defense"": 75}","Coconut Pokémon","When the time comes, one of its three heads
+falls off. Before long, the fallen head grows into
+an Exeggcute."
+104,"Cubone","[""ground""]",4.00,65.00,"[""battle-armor"", ""lightning-rod"", ""rock-head""]","[""monster""]","{""hp"": 50, ""speed"": 35, ""attack"": 50, ""defense"": 95, ""special-attack"": 40, ""special-defense"": 50}","Lonely Pokémon","The skull it wears on its head is that of its dead
+mother. According to some, it will evolve when
+it comes to terms with the pain of her death."
+105,"Marowak","[""ground""]",10.00,450.00,"[""battle-armor"", ""lightning-rod"", ""rock-head""]","[""monster""]","{""hp"": 60, ""speed"": 45, ""attack"": 80, ""defense"": 110, ""special-attack"": 50, ""special-defense"": 80}","Bone Keeper Pokémon","This Pokémon is out for vengeance on its natural
+enemy, Mandibuzz. It throws bones like
+boomerangs to try to take it down."
+106,"Hitmonlee","[""fighting""]",15.00,498.00,"[""unburden"", ""reckless"", ""limber""]","[""humanshape""]","{""hp"": 50, ""speed"": 87, ""attack"": 120, ""defense"": 53, ""special-attack"": 35, ""special-defense"": 110}","Kicking Pokémon","Hitmonlee’s legs freely contract and stretch. Using these
+springlike legs, it bowls over foes with devastating kicks.
+After battle, it rubs down its legs and loosens the muscles
+to overcome fatigue."
+107,"Hitmonchan","[""fighting""]",14.00,502.00,"[""inner-focus"", ""iron-fist"", ""keen-eye""]","[""humanshape""]","{""hp"": 50, ""speed"": 76, ""attack"": 105, ""defense"": 79, ""special-attack"": 35, ""special-defense"": 110}","Punching Pokémon","Hitmonchan is said to possess the spirit of a boxer who had
+been working toward a world championship. This Pokémon
+has an indomitable spirit and will never give up in the face
+of adversity."
+108,"Lickitung","[""normal""]",12.00,655.00,"[""cloud-nine"", ""oblivious"", ""own-tempo""]","[""monster""]","{""hp"": 90, ""speed"": 30, ""attack"": 55, ""defense"": 75, ""special-attack"": 60, ""special-defense"": 75}","Licking Pokémon","Whenever Lickitung comes across something new, it will
+unfailingly give it a lick. It does so because it memorizes things
+by texture and by taste. It is somewhat put off by sour things."
+109,"Koffing","[""poison""]",6.00,10.00,"[""levitate""]","[""indeterminate""]","{""hp"": 40, ""speed"": 35, ""attack"": 65, ""defense"": 95, ""special-attack"": 60, ""special-defense"": 45}","Poison Gas Pokémon","Koffing embodies toxic substances. It mixes the toxins with raw
+garbage to set off a chemical reaction that results in a terribly
+powerful poison gas. The higher the temperature, the more gas
+is concocted by this Pokémon."
+110,"Weezing","[""poison""]",12.00,95.00,"[""levitate""]","[""indeterminate""]","{""hp"": 65, ""speed"": 60, ""attack"": 90, ""defense"": 120, ""special-attack"": 85, ""special-defense"": 70}","Poison Gas Pokémon","Weezing alternately shrinks and inflates its twin bodies to mix
+together toxic gases inside. The more the gases are mixed,
+the more powerful the toxins become. The Pokémon also
+becomes more putrid."
+111,"Rhyhorn","[""rock"", ""ground""]",10.00,1150.00,"[""reckless"", ""rock-head"", ""lightning-rod""]","[""ground"", ""monster""]","{""hp"": 80, ""speed"": 25, ""attack"": 85, ""defense"": 95, ""special-attack"": 30, ""special-defense"": 30}","Spikes Pokémon","Rhyhorn’s brain is very small. It is so dense, while on a run
+it forgets why it started running in the first place. It apparently
+remembers sometimes if it demolishes something."
+112,"Rhydon","[""rock"", ""ground""]",19.00,1200.00,"[""reckless"", ""rock-head"", ""lightning-rod""]","[""ground"", ""monster""]","{""hp"": 105, ""speed"": 40, ""attack"": 130, ""defense"": 120, ""special-attack"": 45, ""special-defense"": 45}","Drill Pokémon","Rhydon has a horn that serves as a drill. It is used for
+destroying rocks and boulders. This Pokémon occasionally
+rams into streams of magma, but the armor-like hide prevents
+it from feeling the heat."
+113,"Chansey","[""normal""]",11.00,346.00,"[""healer"", ""serene-grace"", ""natural-cure""]","[""fairy""]","{""hp"": 250, ""speed"": 50, ""attack"": 5, ""defense"": 5, ""special-attack"": 35, ""special-defense"": 105}","Egg Pokémon","Not only are these Pokémon fast runners,
+they’re also few in number, so anyone who finds
+one must be lucky indeed."
+114,"Tangela","[""grass""]",10.00,350.00,"[""regenerator"", ""leaf-guard"", ""chlorophyll""]","[""plant""]","{""hp"": 65, ""speed"": 60, ""attack"": 55, ""defense"": 115, ""special-attack"": 100, ""special-defense"": 40}","Vine Pokémon","Tangela’s vines snap off easily if they are grabbed. This
+happens without pain, allowing it to make a quick getaway.
+The lost vines are replaced by newly grown vines the very
+next day."
+115,"Kangaskhan","[""normal""]",22.00,800.00,"[""inner-focus"", ""scrappy"", ""early-bird""]","[""monster""]","{""hp"": 105, ""speed"": 90, ""attack"": 95, ""defense"": 80, ""special-attack"": 40, ""special-defense"": 80}","Parent Pokémon","The child in its pouch leaves home after roughly
+three years. That is the only time the mother is
+heard to cry wildly."
+116,"Horsea","[""water""]",4.00,80.00,"[""damp"", ""sniper"", ""swift-swim""]","[""dragon"", ""water1""]","{""hp"": 30, ""speed"": 60, ""attack"": 40, ""defense"": 70, ""special-attack"": 70, ""special-defense"": 25}","Dragon Pokémon","If Horsea senses danger, it will reflexively spray a dense
+black ink from its mouth and try to escape. This Pokémon
+swims by cleverly flapping the fin on its back."
+117,"Seadra","[""water""]",12.00,250.00,"[""damp"", ""sniper"", ""poison-point""]","[""dragon"", ""water1""]","{""hp"": 55, ""speed"": 85, ""attack"": 65, ""defense"": 95, ""special-attack"": 95, ""special-defense"": 45}","Dragon Pokémon","Seadra generates whirlpools by spinning its body.
+The whirlpools are strong enough to swallow even
+fishing boats. This Pokémon weakens prey with
+these currents, then swallows it whole."
+118,"Goldeen","[""water""]",6.00,150.00,"[""lightning-rod"", ""water-veil"", ""swift-swim""]","[""water2""]","{""hp"": 45, ""speed"": 63, ""attack"": 67, ""defense"": 60, ""special-attack"": 35, ""special-defense"": 50}","Goldfish Pokémon","Spellbound by the length of its horn and the
+beauty of its fins, many strange Trainers raise
+Goldeen and nothing but Goldeen."
+119,"Seaking","[""water""]",13.00,390.00,"[""lightning-rod"", ""water-veil"", ""swift-swim""]","[""water2""]","{""hp"": 80, ""speed"": 68, ""attack"": 92, ""defense"": 65, ""special-attack"": 65, ""special-defense"": 80}","Goldfish Pokémon","Trainers who are crazy for Seaking are divided
+into horn enthusiasts and fin enthusiasts.
+The two groups do not get along well."
+120,"Staryu","[""water""]",8.00,345.00,"[""analytic"", ""natural-cure"", ""illuminate""]","[""water3""]","{""hp"": 30, ""speed"": 85, ""attack"": 45, ""defense"": 55, ""special-attack"": 70, ""special-defense"": 55}","Star Shape Pokémon","This Pokémon gets nibbled on by Lumineon and
+others. Thanks to its red core, it regenerates
+fast, so it’s unconcerned by their snack attacks."
+121,"Starmie","[""psychic"", ""water""]",11.00,800.00,"[""analytic"", ""natural-cure"", ""illuminate""]","[""water3""]","{""hp"": 60, ""speed"": 115, ""attack"": 75, ""defense"": 85, ""special-attack"": 100, ""special-defense"": 85}","Mysterious Pokémon","Its unusual body shape, reminiscent of abstract
+art, led local people to spread rumors that this
+Pokémon may be an invader from outer space."
+122,"Mr. Mime","[""fairy"", ""psychic""]",13.00,545.00,"[""technician"", ""filter"", ""soundproof""]","[""humanshape""]","{""hp"": 40, ""speed"": 90, ""attack"": 45, ""defense"": 65, ""special-attack"": 100, ""special-defense"": 120}","Barrier Pokémon","Mr. Mime is a master of pantomime. Its gestures and motions
+convince watchers that something unseeable actually exists.
+Once the watchers are convinced, the unseeable thing exists
+as if it were real."
+123,"Scyther","[""flying"", ""bug""]",15.00,560.00,"[""steadfast"", ""technician"", ""swarm""]","[""bug""]","{""hp"": 70, ""speed"": 105, ""attack"": 110, ""defense"": 80, ""special-attack"": 55, ""special-defense"": 80}","Mantis Pokémon","While young, they live together deep in the
+mountains, training themselves in how to fight
+with their scythes and move at high speeds."
+124,"Jynx","[""psychic"", ""ice""]",14.00,406.00,"[""dry-skin"", ""forewarn"", ""oblivious""]","[""humanshape""]","{""hp"": 65, ""speed"": 95, ""attack"": 50, ""defense"": 35, ""special-attack"": 115, ""special-defense"": 95}","Human Shape Pokémon","Jynx walks rhythmically, swaying and shaking its hips
+as if it were dancing. Its motions are so bouncingly alluring,
+people seeing it are compelled to shake their hips without
+giving any thought to what they are doing."
+125,"Electabuzz","[""electric""]",11.00,300.00,"[""vital-spirit"", ""static""]","[""humanshape""]","{""hp"": 65, ""speed"": 105, ""attack"": 83, ""defense"": 57, ""special-attack"": 95, ""special-defense"": 85}","Electric Pokémon","Electricity leaks from it in amounts far greater
+than the amount of electricity it eats."
+126,"Magmar","[""fire""]",13.00,445.00,"[""vital-spirit"", ""flame-body""]","[""humanshape""]","{""hp"": 65, ""speed"": 93, ""attack"": 95, ""defense"": 57, ""special-attack"": 100, ""special-defense"": 85}","Spitfire Pokémon","When angered, it spouts brilliant fire from all
+over its body. It doesn’t calm down until its
+opponent has burned to ash."
+127,"Pinsir","[""bug""]",15.00,550.00,"[""moxie"", ""mold-breaker"", ""hyper-cutter""]","[""bug""]","{""hp"": 65, ""speed"": 85, ""attack"": 125, ""defense"": 100, ""special-attack"": 55, ""special-defense"": 70}","Stag Beetle Pokémon","One solid blow from its horns is enough to split
+apart a large tree. Its greatest rival in Alola
+is Vikavolt."
+128,"Tauros","[""normal""]",14.00,884.00,"[""sheer-force"", ""anger-point"", ""intimidate""]","[""ground""]","{""hp"": 75, ""speed"": 110, ""attack"": 100, ""defense"": 95, ""special-attack"": 40, ""special-defense"": 70}","Wild Bull Pokémon","Although it’s known to be a fierce Pokémon,
+Tauros in the Alola region are said to possess
+a measure of calmness."
+129,"Magikarp","[""water""]",9.00,100.00,"[""rattled"", ""swift-swim""]","[""dragon"", ""water2""]","{""hp"": 20, ""speed"": 80, ""attack"": 10, ""defense"": 55, ""special-attack"": 15, ""special-defense"": 20}","Fish Pokémon","Its reckless leaps make it easy pickings for
+predators. On the bright side, many Pokémon
+enjoy longer life spans, thanks to Magikarp."
+130,"Gyarados","[""flying"", ""water""]",65.00,2350.00,"[""moxie"", ""intimidate""]","[""dragon"", ""water2""]","{""hp"": 95, ""speed"": 81, ""attack"": 125, ""defense"": 79, ""special-attack"": 60, ""special-defense"": 100}","Atrocious Pokémon","There are people who swear that any place
+Gyarados appears is fated for destruction."
+131,"Lapras","[""ice"", ""water""]",25.00,2200.00,"[""hydration"", ""shell-armor"", ""water-absorb""]","[""water1"", ""monster""]","{""hp"": 130, ""speed"": 60, ""attack"": 85, ""defense"": 80, ""special-attack"": 85, ""special-defense"": 95}","Transport Pokémon","These Pokémon were once near extinction due
+to poaching. Following protective regulations,
+there is now an overabundance of them."
+132,"Ditto","[""normal""]",3.00,40.00,"[""imposter"", ""limber""]","[""ditto""]","{""hp"": 48, ""speed"": 48, ""attack"": 48, ""defense"": 48, ""special-attack"": 48, ""special-defense"": 48}","Transform Pokémon","With its astonishing capacity for
+metamorphosis, it can get along with anything.
+It does not get along well with its fellow Ditto."
+133,"Eevee","[""normal""]",3.00,65.00,"[""anticipation"", ""adaptability"", ""run-away""]","[""ground""]","{""hp"": 55, ""speed"": 55, ""attack"": 55, ""defense"": 50, ""special-attack"": 45, ""special-defense"": 65}","Evolution Pokémon","Current studies show it can evolve into an
+incredible eight different species of Pokémon."
+134,"Vaporeon","[""water""]",10.00,290.00,"[""hydration"", ""water-absorb""]","[""ground""]","{""hp"": 130, ""speed"": 65, ""attack"": 65, ""defense"": 60, ""special-attack"": 110, ""special-defense"": 95}","Bubble Jet Pokémon","Blending in with the water and erasing all signs
+of its presence, it patiently waits for its prey,
+fish Pokémon."
+135,"Jolteon","[""electric""]",8.00,245.00,"[""quick-feet"", ""volt-absorb""]","[""ground""]","{""hp"": 65, ""speed"": 130, ""attack"": 65, ""defense"": 60, ""special-attack"": 110, ""special-defense"": 95}","Lightning Pokémon","When its fur stands on end, that’s a sign it’s
+about to give off a jolt of electricity. Take care,
+as sometimes lightning strikes next to it, too."
+136,"Flareon","[""fire""]",9.00,250.00,"[""guts"", ""flash-fire""]","[""ground""]","{""hp"": 65, ""speed"": 65, ""attack"": 130, ""defense"": 60, ""special-attack"": 95, ""special-defense"": 110}","Flame Pokémon","Its average body temperature is between 1,300
+and 1,500 degrees Fahrenheit. In its internal
+flame sac, temperatures reach 3,000 degrees."
+137,"Porygon","[""normal""]",8.00,365.00,"[""analytic"", ""download"", ""trace""]","[""mineral""]","{""hp"": 65, ""speed"": 40, ""attack"": 60, ""defense"": 70, ""special-attack"": 85, ""special-defense"": 75}","Virtual Pokémon","It can convert its body into digital data,
+which enables it to enter cyberspace."
+138,"Omanyte","[""water"", ""rock""]",4.00,75.00,"[""weak-armor"", ""shell-armor"", ""swift-swim""]","[""water3"", ""water1""]","{""hp"": 35, ""speed"": 35, ""attack"": 40, ""defense"": 100, ""special-attack"": 90, ""special-defense"": 55}","Spiral Pokémon","Omanyte is one of the ancient and long-since-extinct Pokémon
+that have been regenerated from fossils by people. If attacked
+by an enemy, it withdraws itself inside its hard shell."
+139,"Omastar","[""water"", ""rock""]",10.00,350.00,"[""weak-armor"", ""shell-armor"", ""swift-swim""]","[""water3"", ""water1""]","{""hp"": 70, ""speed"": 55, ""attack"": 60, ""defense"": 125, ""special-attack"": 115, ""special-defense"": 70}","Spiral Pokémon","Omastar uses its tentacles to capture its prey. It is
+believed to have become extinct because its shell grew too
+large and heavy, causing its movements to become too slow
+and ponderous."
+140,"Kabuto","[""water"", ""rock""]",5.00,115.00,"[""weak-armor"", ""battle-armor"", ""swift-swim""]","[""water3"", ""water1""]","{""hp"": 30, ""speed"": 55, ""attack"": 80, ""defense"": 90, ""special-attack"": 55, ""special-defense"": 45}","Shellfish Pokémon","Kabuto is a Pokémon that has been regenerated from a fossil.
+However, in extremely rare cases, living examples have
+been discovered. The Pokémon has not changed at all for
+300 million years."
+141,"Kabutops","[""water"", ""rock""]",13.00,405.00,"[""weak-armor"", ""battle-armor"", ""swift-swim""]","[""water3"", ""water1""]","{""hp"": 60, ""speed"": 80, ""attack"": 115, ""defense"": 105, ""special-attack"": 65, ""special-defense"": 70}","Shellfish Pokémon","Kabutops swam underwater to hunt for its prey in ancient
+times. The Pokémon was apparently evolving from being a
+water dweller to living on land as evident from the beginnings
+of change in its gills and legs."
+142,"Aerodactyl","[""flying"", ""rock""]",18.00,590.00,"[""unnerve"", ""pressure"", ""rock-head""]","[""flying""]","{""hp"": 80, ""speed"": 130, ""attack"": 105, ""defense"": 65, ""special-attack"": 60, ""special-defense"": 75}","Fossil Pokémon","In ancient times, it ruled the skies. A widely
+accepted theory is that it went extinct due to
+a large meteor impact."
+143,"Snorlax","[""normal""]",21.00,4600.00,"[""gluttony"", ""thick-fat"", ""immunity""]","[""monster""]","{""hp"": 160, ""speed"": 30, ""attack"": 110, ""defense"": 65, ""special-attack"": 65, ""special-defense"": 110}","Sleeping Pokémon","It eats nearly 900 pounds of food every day.
+It starts nodding off while eating—and continues
+to eat even while it’s asleep."
+144,"Articuno","[""flying"", ""ice""]",17.00,554.00,"[""snow-cloak"", ""pressure""]","[""no-eggs""]","{""hp"": 90, ""speed"": 85, ""attack"": 85, ""defense"": 100, ""special-attack"": 95, ""special-defense"": 125}","Freeze Pokémon","Articuno is a legendary bird Pokémon that can control ice.
+The flapping of its wings chills the air. As a result, it is said
+that when this Pokémon flies, snow will fall."
+145,"Zapdos","[""flying"", ""electric""]",16.00,526.00,"[""static"", ""pressure""]","[""no-eggs""]","{""hp"": 90, ""speed"": 100, ""attack"": 90, ""defense"": 85, ""special-attack"": 125, ""special-defense"": 90}","Electric Pokémon","Zapdos is a legendary bird Pokémon that has the ability
+to control electricity. It usually lives in thunderclouds.
+The Pokémon gains power if it is stricken by lightning bolts."
+146,"Moltres","[""flying"", ""fire""]",20.00,600.00,"[""flame-body"", ""pressure""]","[""no-eggs""]","{""hp"": 90, ""speed"": 90, ""attack"": 100, ""defense"": 90, ""special-attack"": 125, ""special-defense"": 85}","Flame Pokémon","Moltres is a legendary bird Pokémon that has the ability
+to control fire. If this Pokémon is injured, it is said to dip its
+body in the molten magma of a volcano to burn and heal itself."
+147,"Dratini","[""dragon""]",18.00,33.00,"[""marvel-scale"", ""shed-skin""]","[""dragon"", ""water1""]","{""hp"": 41, ""speed"": 50, ""attack"": 64, ""defense"": 45, ""special-attack"": 50, ""special-defense"": 50}","Dragon Pokémon","After a 10-hour struggle, a fisherman was able
+to pull one up and confirm its existence."
+148,"Dragonair","[""dragon""]",40.00,165.00,"[""marvel-scale"", ""shed-skin""]","[""dragon"", ""water1""]","{""hp"": 61, ""speed"": 70, ""attack"": 84, ""defense"": 65, ""special-attack"": 70, ""special-defense"": 70}","Dragon Pokémon","From time immemorial, it has been venerated by
+agricultural peoples as an entity able to control
+the weather."
+149,"Dragonite","[""flying"", ""dragon""]",22.00,2100.00,"[""multiscale"", ""inner-focus""]","[""dragon"", ""water1""]","{""hp"": 91, ""speed"": 80, ""attack"": 134, ""defense"": 95, ""special-attack"": 100, ""special-defense"": 100}","Dragon Pokémon","Incur the wrath of this normally calm Pokémon
+at your peril, because it will smash everything
+to smithereens before it’s satisfied."
+150,"Mewtwo","[""psychic""]",20.00,1220.00,"[""unnerve"", ""pressure""]","[""no-eggs""]","{""hp"": 106, ""speed"": 130, ""attack"": 110, ""defense"": 90, ""special-attack"": 154, ""special-defense"": 90}","Genetic Pokémon","Mewtwo is a Pokémon that was created by genetic
+manipulation. However, even though the scientific power
+of humans created this Pokémon’s body, they failed to
+endow Mewtwo with a compassionate heart."
+151,"Mew","[""psychic""]",4.00,40.00,"[""synchronize""]","[""no-eggs""]","{""hp"": 100, ""speed"": 100, ""attack"": 100, ""defense"": 100, ""special-attack"": 100, ""special-defense"": 100}","New Species Pokémon","Mew is said to possess the genetic composition of all
+Pokémon. It is capable of making itself invisible at will,
+so it entirely avoids notice even if it approaches people."
+152,"Chikorita","[""grass""]",9.00,64.00,"[""leaf-guard"", ""overgrow""]","[""plant"", ""monster""]","{""hp"": 45, ""speed"": 45, ""attack"": 49, ""defense"": 65, ""special-attack"": 49, ""special-defense"": 65}","Leaf Pokémon","In battle, Chikorita waves its leaf around to keep the foe at
+bay. However, a sweet fragrance also wafts from the leaf,
+becalming the battling Pokémon and creating a cozy,
+friendly atmosphere all around."
+153,"Bayleef","[""grass""]",12.00,158.00,"[""leaf-guard"", ""overgrow""]","[""plant"", ""monster""]","{""hp"": 60, ""speed"": 60, ""attack"": 62, ""defense"": 80, ""special-attack"": 63, ""special-defense"": 80}","Leaf Pokémon","Bayleef’s neck is ringed by curled-up leaves. Inside each
+tubular leaf is a small shoot of a tree. The fragrance of this
+shoot makes people peppy."
+154,"Meganium","[""grass""]",18.00,1005.00,"[""leaf-guard"", ""overgrow""]","[""plant"", ""monster""]","{""hp"": 80, ""speed"": 80, ""attack"": 82, ""defense"": 100, ""special-attack"": 83, ""special-defense"": 100}","Herb Pokémon","The fragrance of Meganium’s flower soothes and calms
+emotions. In battle, this Pokémon gives off more of its
+becalming scent to blunt the foe’s fighting spirit."
+155,"Cyndaquil","[""fire""]",5.00,79.00,"[""flash-fire"", ""blaze""]","[""ground""]","{""hp"": 39, ""speed"": 65, ""attack"": 52, ""defense"": 43, ""special-attack"": 60, ""special-defense"": 50}","Fire Mouse Pokémon","Cyndaquil protects itself by flaring up the flames on its back.
+The flames are vigorous if the Pokémon is angry. However, if it
+is tired, the flames splutter fitfully with incomplete combustion."
+156,"Quilava","[""fire""]",9.00,190.00,"[""flash-fire"", ""blaze""]","[""ground""]","{""hp"": 58, ""speed"": 80, ""attack"": 64, ""defense"": 58, ""special-attack"": 80, ""special-defense"": 65}","Volcano Pokémon","Quilava keeps its foes at bay with the intensity of its flames
+and gusts of superheated air. This Pokémon applies its
+outstanding nimbleness to dodge attacks even while scorching
+the foe with flames."
+157,"Typhlosion","[""fire""]",17.00,795.00,"[""flash-fire"", ""blaze""]","[""ground""]","{""hp"": 78, ""speed"": 100, ""attack"": 84, ""defense"": 78, ""special-attack"": 109, ""special-defense"": 85}","Volcano Pokémon","Typhlosion obscures itself behind a shimmering heat haze that
+it creates using its intensely hot flames. This Pokémon creates
+blazing explosive blasts that burn everything to cinders."
+158,"Totodile","[""water""]",6.00,95.00,"[""sheer-force"", ""torrent""]","[""water1"", ""monster""]","{""hp"": 50, ""speed"": 43, ""attack"": 65, ""defense"": 64, ""special-attack"": 44, ""special-defense"": 48}","Big Jaw Pokémon","Despite the smallness of its body, Totodile’s jaws are very
+powerful. While the Pokémon may think it is just playfully
+nipping, its bite has enough power to cause serious injury."
+159,"Croconaw","[""water""]",11.00,250.00,"[""sheer-force"", ""torrent""]","[""water1"", ""monster""]","{""hp"": 65, ""speed"": 58, ""attack"": 80, ""defense"": 80, ""special-attack"": 59, ""special-defense"": 63}","Big Jaw Pokémon","Once Croconaw has clamped its jaws on its foe, it will
+absolutely not let go. Because the tips of its fangs are
+forked back like barbed fishhooks, they become impossible
+to remove when they have sunk in."
+160,"Feraligatr","[""water""]",23.00,888.00,"[""sheer-force"", ""torrent""]","[""water1"", ""monster""]","{""hp"": 85, ""speed"": 78, ""attack"": 105, ""defense"": 100, ""special-attack"": 79, ""special-defense"": 83}","Big Jaw Pokémon","Feraligatr intimidates its foes by opening its huge mouth.
+In battle, it will kick the ground hard with its thick and powerful
+hind legs to charge at the foe at an incredible speed."
+161,"Sentret","[""normal""]",8.00,60.00,"[""frisk"", ""keen-eye"", ""run-away""]","[""ground""]","{""hp"": 35, ""speed"": 20, ""attack"": 46, ""defense"": 34, ""special-attack"": 35, ""special-defense"": 45}","Scout Pokémon","When Sentret sleeps, it does so while another stands guard.
+The sentry wakes the others at the first sign of danger. When
+this Pokémon becomes separated from its pack, it becomes
+incapable of sleep due to fear."
+162,"Furret","[""normal""]",18.00,325.00,"[""frisk"", ""keen-eye"", ""run-away""]","[""ground""]","{""hp"": 85, ""speed"": 90, ""attack"": 76, ""defense"": 64, ""special-attack"": 45, ""special-defense"": 55}","Long Body Pokémon","Furret has a very slim build. When under attack, it can slickly
+squirm through narrow spaces and get away. In spite of its
+short limbs, this Pokémon is very nimble and fleet."
+163,"Hoothoot","[""flying"", ""normal""]",7.00,212.00,"[""tinted-lens"", ""keen-eye"", ""insomnia""]","[""flying""]","{""hp"": 60, ""speed"": 50, ""attack"": 30, ""defense"": 30, ""special-attack"": 36, ""special-defense"": 56}","Owl Pokémon","Hoothoot has an internal organ that senses and tracks the
+earth’s rotation. Using this special organ, this Pokémon
+begins hooting at precisely the same time every day."
+164,"Noctowl","[""flying"", ""normal""]",16.00,408.00,"[""tinted-lens"", ""keen-eye"", ""insomnia""]","[""flying""]","{""hp"": 100, ""speed"": 70, ""attack"": 50, ""defense"": 50, ""special-attack"": 86, ""special-defense"": 96}","Owl Pokémon","Noctowl never fails at catching prey in darkness. This Pokémon
+owes its success to its superior vision that allows it to see in
+minimal light, and to its soft, supple wings that make no sound
+in flight."
+165,"Ledyba","[""flying"", ""bug""]",10.00,108.00,"[""rattled"", ""early-bird"", ""swarm""]","[""bug""]","{""hp"": 40, ""speed"": 55, ""attack"": 20, ""defense"": 30, ""special-attack"": 40, ""special-defense"": 80}","Five Star Pokémon","They communicate with one another using bodily
+fluids that give off odors. When they’re angry,
+their odor smells sour."
+166,"Ledian","[""flying"", ""bug""]",14.00,356.00,"[""iron-fist"", ""early-bird"", ""swarm""]","[""bug""]","{""hp"": 55, ""speed"": 85, ""attack"": 35, ""defense"": 50, ""special-attack"": 55, ""special-defense"": 110}","Five Star Pokémon","In battle, it throws punches with all four arms.
+The power of each individual blow is piddly,
+so it aims to win by quantity rather than quality."
+167,"Spinarak","[""poison"", ""bug""]",5.00,85.00,"[""sniper"", ""insomnia"", ""swarm""]","[""bug""]","{""hp"": 40, ""speed"": 30, ""attack"": 60, ""defense"": 40, ""special-attack"": 40, ""special-defense"": 40}","String Spit Pokémon","Some fishermen weave its sturdy thread into
+nets to catch fish Pokémon."
+168,"Ariados","[""poison"", ""bug""]",11.00,335.00,"[""sniper"", ""insomnia"", ""swarm""]","[""bug""]","{""hp"": 70, ""speed"": 40, ""attack"": 90, ""defense"": 70, ""special-attack"": 60, ""special-defense"": 70}","Long Leg Pokémon","It spins thread from both its rear and its mouth.
+Then it wraps its prey up in thread and sips
+their bodily fluids at its leisure."
+169,"Crobat","[""flying"", ""poison""]",18.00,750.00,"[""infiltrator"", ""inner-focus""]","[""flying""]","{""hp"": 85, ""speed"": 130, ""attack"": 90, ""defense"": 80, ""special-attack"": 70, ""special-defense"": 80}","Bat Pokémon","Silent and swift in its four-winged flight, it bites
+down on its prey before they realize what’s
+happening. In a heartbeat, it drains their blood."
+170,"Chinchou","[""electric"", ""water""]",5.00,120.00,"[""water-absorb"", ""illuminate"", ""volt-absorb""]","[""water2""]","{""hp"": 75, ""speed"": 67, ""attack"": 38, ""defense"": 38, ""special-attack"": 56, ""special-defense"": 56}","Angler Pokémon","It lives in the depths beyond the reach of
+sunlight. It flashes lights on its antennae
+to communicate with others of its kind."
+171,"Lanturn","[""electric"", ""water""]",12.00,225.00,"[""water-absorb"", ""illuminate"", ""volt-absorb""]","[""water2""]","{""hp"": 125, ""speed"": 67, ""attack"": 58, ""defense"": 58, ""special-attack"": 76, ""special-defense"": 76}","Light Pokémon","This Pokémon flashes a bright light that blinds
+its prey. This creates an opening for it to deliver
+an electrical attack."
+172,"Pichu","[""electric""]",3.00,20.00,"[""lightning-rod"", ""static""]","[""no-eggs""]","{""hp"": 20, ""speed"": 60, ""attack"": 40, ""defense"": 15, ""special-attack"": 35, ""special-defense"": 35}","Tiny Mouse Pokémon","Despite this Pokémon’s cute appearance, those
+who want to live with one should prepare to be
+on the receiving end of its electric jolts."
+173,"Cleffa","[""fairy""]",3.00,30.00,"[""friend-guard"", ""magic-guard"", ""cute-charm""]","[""no-eggs""]","{""hp"": 50, ""speed"": 15, ""attack"": 25, ""defense"": 28, ""special-attack"": 45, ""special-defense"": 55}","Star Shape Pokémon","Because of its silhouette, it’s believed to be a
+star reborn. For some reason, it loves Minior."
+174,"Igglybuff","[""fairy"", ""normal""]",3.00,10.00,"[""friend-guard"", ""competitive"", ""cute-charm""]","[""no-eggs""]","{""hp"": 90, ""speed"": 15, ""attack"": 30, ""defense"": 15, ""special-attack"": 40, ""special-defense"": 20}","Balloon Pokémon","It moves by bouncing along. As it moves a lot,
+it sweats, and its body gives off a sweet aroma."
+175,"Togepi","[""fairy""]",3.00,15.00,"[""super-luck"", ""serene-grace"", ""hustle""]","[""no-eggs""]","{""hp"": 35, ""speed"": 20, ""attack"": 20, ""defense"": 65, ""special-attack"": 40, ""special-defense"": 65}","Spike Ball Pokémon","As its energy, Togepi uses the positive emotions of
+compassion and pleasure exuded by people and Pokémon.
+This Pokémon stores up feelings of happiness inside its shell,
+then shares them with others."
+176,"Togetic","[""flying"", ""fairy""]",6.00,32.00,"[""super-luck"", ""serene-grace"", ""hustle""]","[""fairy"", ""flying""]","{""hp"": 55, ""speed"": 40, ""attack"": 40, ""defense"": 85, ""special-attack"": 80, ""special-defense"": 105}","Happiness Pokémon","Togetic is said to be a Pokémon that brings good fortune.
+When the Pokémon spots someone who is pure of heart,
+it is said to appear and share its happiness with that person."
+177,"Natu","[""flying"", ""psychic""]",2.00,20.00,"[""magic-bounce"", ""early-bird"", ""synchronize""]","[""flying""]","{""hp"": 40, ""speed"": 70, ""attack"": 50, ""defense"": 45, ""special-attack"": 70, ""special-defense"": 45}","Tiny Bird Pokémon","Natu has a highly developed jumping ability. The Pokémon
+flaps and leaps onto tree branches that are taller than
+grown-up people to pick at the tree’s new shoots."
+178,"Xatu","[""flying"", ""psychic""]",15.00,150.00,"[""magic-bounce"", ""early-bird"", ""synchronize""]","[""flying""]","{""hp"": 65, ""speed"": 95, ""attack"": 75, ""defense"": 70, ""special-attack"": 95, ""special-defense"": 70}","Mystic Pokémon","Xatu is known to stand motionless while staring at the sun all
+day long. Some people revere it as a mystical Pokémon out of
+their belief that Xatu is in possession of the power to see into
+the future."
+179,"Mareep","[""electric""]",6.00,78.00,"[""plus"", ""static""]","[""ground"", ""monster""]","{""hp"": 55, ""speed"": 35, ""attack"": 40, ""defense"": 40, ""special-attack"": 65, ""special-defense"": 45}","Wool Pokémon","Mareep’s fluffy coat of wool rubs together and builds a static
+charge. The more static electricity is charged, the more brightly
+the lightbulb at the tip of its tail glows."
+180,"Flaaffy","[""electric""]",8.00,133.00,"[""plus"", ""static""]","[""ground"", ""monster""]","{""hp"": 70, ""speed"": 45, ""attack"": 55, ""defense"": 55, ""special-attack"": 80, ""special-defense"": 60}","Wool Pokémon","Flaaffy’s wool quality changes so that it can generate
+a high amount of static electricity with a small amount of
+wool. The bare and slick parts of its hide are shielded
+against electricity."
+181,"Ampharos","[""electric""]",14.00,615.00,"[""plus"", ""static""]","[""ground"", ""monster""]","{""hp"": 90, ""speed"": 55, ""attack"": 75, ""defense"": 85, ""special-attack"": 115, ""special-defense"": 90}","Light Pokémon","Ampharos gives off so much light that it can be seen even from
+space. People in the old days used the light of this Pokémon
+to send signals back and forth with others far away."
+182,"Bellossom","[""grass""]",4.00,58.00,"[""healer"", ""chlorophyll""]","[""plant""]","{""hp"": 75, ""speed"": 50, ""attack"": 80, ""defense"": 95, ""special-attack"": 90, ""special-defense"": 100}","Flower Pokémon","A Bellossom grows flowers more beautifully if it has evolved
+from a smelly Gloom—the more stinky the better. At night, this
+Pokémon closes its petals and goes to sleep."
+183,"Marill","[""fairy"", ""water""]",4.00,85.00,"[""sap-sipper"", ""huge-power"", ""thick-fat""]","[""fairy"", ""water1""]","{""hp"": 70, ""speed"": 40, ""attack"": 20, ""defense"": 50, ""special-attack"": 20, ""special-defense"": 50}","Aqua Mouse Pokémon","When fishing for food at the edge of a fast-running stream,
+Marill wraps its tail around the trunk of a tree. This Pokémon’s
+tail is flexible and configured to stretch."
+184,"Azumarill","[""fairy"", ""water""]",8.00,285.00,"[""sap-sipper"", ""huge-power"", ""thick-fat""]","[""fairy"", ""water1""]","{""hp"": 100, ""speed"": 50, ""attack"": 50, ""defense"": 80, ""special-attack"": 60, ""special-defense"": 80}","Aqua Rabbit Pokémon","Azumarill can make balloons out of air. It makes these air
+balloons if it spots a drowning Pokémon. The air balloons
+enable the Pokémon in trouble to breathe."
+185,"Sudowoodo","[""rock""]",12.00,380.00,"[""rattled"", ""rock-head"", ""sturdy""]","[""mineral""]","{""hp"": 70, ""speed"": 30, ""attack"": 100, ""defense"": 115, ""special-attack"": 30, ""special-defense"": 65}","Imitation Pokémon","Apparently, the larger the green parts of this
+Pokémon, the more collectors value it. It’s a
+particular favorite among elderly people."
+186,"Politoed","[""water""]",11.00,339.00,"[""drizzle"", ""damp"", ""water-absorb""]","[""water1""]","{""hp"": 90, ""speed"": 70, ""attack"": 75, ""defense"": 75, ""special-attack"": 90, ""special-defense"": 100}","Frog Pokémon","It’s the leader of Poliwag and Poliwhirl.
+When Politoed roars, they all cower in fear."
+187,"Hoppip","[""flying"", ""grass""]",4.00,5.00,"[""infiltrator"", ""leaf-guard"", ""chlorophyll""]","[""plant"", ""fairy""]","{""hp"": 35, ""speed"": 50, ""attack"": 35, ""defense"": 40, ""special-attack"": 35, ""special-defense"": 55}","Cottonweed Pokémon","This Pokémon drifts and floats with the wind. If it senses the
+approach of strong winds, Hoppip links its leaves with other
+Hoppip to prepare against being blown away."
+188,"Skiploom","[""flying"", ""grass""]",6.00,10.00,"[""infiltrator"", ""leaf-guard"", ""chlorophyll""]","[""plant"", ""fairy""]","{""hp"": 55, ""speed"": 80, ""attack"": 45, ""defense"": 50, ""special-attack"": 45, ""special-defense"": 65}","Cottonweed Pokémon","Skiploom’s flower blossoms when the temperature rises
+above 64 degrees Fahrenheit. How much the flower opens
+depends on the temperature. For that reason, this Pokémon
+is sometimes used as a thermometer."
+189,"Jumpluff","[""flying"", ""grass""]",8.00,30.00,"[""infiltrator"", ""leaf-guard"", ""chlorophyll""]","[""plant"", ""fairy""]","{""hp"": 75, ""speed"": 110, ""attack"": 55, ""defense"": 70, ""special-attack"": 55, ""special-defense"": 95}","Cottonweed Pokémon","Jumpluff rides warm southern winds to cross the sea and fly to
+foreign lands. The Pokémon descends to the ground when it
+encounters cold air while it is floating."
+190,"Aipom","[""normal""]",8.00,115.00,"[""skill-link"", ""pickup"", ""run-away""]","[""ground""]","{""hp"": 55, ""speed"": 85, ""attack"": 70, ""defense"": 55, ""special-attack"": 40, ""special-defense"": 55}","Long Tail Pokémon","Aipom’s tail ends in a hand-like appendage that can be cleverly
+manipulated. However, because the Pokémon uses its tail so
+much, its real hands have become rather clumsy."
+191,"Sunkern","[""grass""]",3.00,18.00,"[""early-bird"", ""solar-power"", ""chlorophyll""]","[""plant""]","{""hp"": 30, ""speed"": 30, ""attack"": 30, ""defense"": 30, ""special-attack"": 30, ""special-defense"": 30}","Seed Pokémon","Sunkern tries to move as little as it possibly can. It does so
+because it tries to conserve all the nutrients it has stored in its
+body for its evolution. It will not eat a thing, subsisting only on
+morning dew."
+192,"Sunflora","[""grass""]",8.00,85.00,"[""early-bird"", ""solar-power"", ""chlorophyll""]","[""plant""]","{""hp"": 75, ""speed"": 30, ""attack"": 75, ""defense"": 55, ""special-attack"": 105, ""special-defense"": 85}","Sun Pokémon","Sunflora converts solar energy into nutrition. It moves around
+actively in the daytime when it is warm. It stops moving as
+soon as the sun goes down for the night."
+193,"Yanma","[""flying"", ""bug""]",12.00,380.00,"[""frisk"", ""compound-eyes"", ""speed-boost""]","[""bug""]","{""hp"": 65, ""speed"": 95, ""attack"": 65, ""defense"": 45, ""special-attack"": 75, ""special-defense"": 45}","Clear Wing Pokémon","Yanma is capable of seeing 360 degrees without having to
+move its eyes. It is a great flier that is adept at making sudden
+stops and turning midair. This Pokémon uses its flying ability
+to quickly chase down targeted prey."
+194,"Wooper","[""ground"", ""water""]",4.00,85.00,"[""unaware"", ""water-absorb"", ""damp""]","[""ground"", ""water1""]","{""hp"": 55, ""speed"": 15, ""attack"": 45, ""defense"": 45, ""special-attack"": 25, ""special-defense"": 25}","Water Fish Pokémon","Wooper usually lives in water. However, it occasionally comes
+out onto land in search of food. On land, it coats its body with
+a gooey, toxic film."
+195,"Quagsire","[""ground"", ""water""]",14.00,750.00,"[""unaware"", ""water-absorb"", ""damp""]","[""ground"", ""water1""]","{""hp"": 95, ""speed"": 35, ""attack"": 85, ""defense"": 85, ""special-attack"": 65, ""special-defense"": 65}","Water Fish Pokémon","Quagsire hunts for food by leaving its mouth wide open in
+water and waiting for its prey to blunder in unaware. Because
+the Pokémon does not move, it does not get very hungry."
+196,"Espeon","[""psychic""]",9.00,265.00,"[""magic-bounce"", ""synchronize""]","[""ground""]","{""hp"": 65, ""speed"": 110, ""attack"": 65, ""defense"": 60, ""special-attack"": 130, ""special-defense"": 95}","Sun Pokémon","It unleashes psychic power from the orb on its
+forehead. When its power is exhausted, the orb
+grows dull and dark."
+197,"Umbreon","[""dark""]",10.00,270.00,"[""inner-focus"", ""synchronize""]","[""ground""]","{""hp"": 95, ""speed"": 65, ""attack"": 65, ""defense"": 110, ""special-attack"": 60, ""special-defense"": 130}","Moonlight Pokémon","With its black fur, it blends into the darkness.
+It bides its time, and when prey appears, this
+Pokémon goes for its throat, and then eats it."
+198,"Murkrow","[""flying"", ""dark""]",5.00,21.00,"[""prankster"", ""super-luck"", ""insomnia""]","[""flying""]","{""hp"": 60, ""speed"": 91, ""attack"": 85, ""defense"": 42, ""special-attack"": 85, ""special-defense"": 42}","Darkness Pokémon","Seen as a symbol of bad luck, it’s generally
+disliked. Yet it gives presents—objects that
+sparkle or shine—to Trainers it’s close to."
+199,"Slowking","[""psychic"", ""water""]",20.00,795.00,"[""regenerator"", ""own-tempo"", ""oblivious""]","[""water1"", ""monster""]","{""hp"": 95, ""speed"": 30, ""attack"": 75, ""defense"": 80, ""special-attack"": 100, ""special-defense"": 110}","Royal Pokémon","This Pokémon is so famed for its intellect that a
+proverb still persists in some regions: “When in
+doubt, ask Slowking.”"
+200,"Misdreavus","[""ghost""]",7.00,10.00,"[""levitate""]","[""indeterminate""]","{""hp"": 60, ""speed"": 85, ""attack"": 60, ""defense"": 60, ""special-attack"": 85, ""special-defense"": 85}","Screech Pokémon","If you hear a sobbing sound emanating from a
+vacant room, it’s undoubtedly a bit of mischief
+from Misdreavus."
+201,"Unown","[""psychic""]",5.00,50.00,"[""levitate""]","[""no-eggs""]","{""hp"": 48, ""speed"": 48, ""attack"": 72, ""defense"": 48, ""special-attack"": 72, ""special-defense"": 48}","Symbol Pokémon","This Pokémon is shaped like ancient writing. It is a mystery as
+to which came first, the ancient writings or the various Unown.
+Research into this topic is ongoing but nothing is known."
+202,"Wobbuffet","[""psychic""]",13.00,285.00,"[""telepathy"", ""shadow-tag""]","[""indeterminate""]","{""hp"": 190, ""speed"": 33, ""attack"": 33, ""defense"": 58, ""special-attack"": 33, ""special-defense"": 58}","Patient Pokémon","Wobbuffet does nothing but endure attacks—it won’t attack on
+its own. However, it won’t endure an attack on its tail. When
+that happens, the Pokémon will try to take the foe with it using
+Destiny Bond."
+203,"Girafarig","[""psychic"", ""normal""]",15.00,415.00,"[""sap-sipper"", ""early-bird"", ""inner-focus""]","[""ground""]","{""hp"": 70, ""speed"": 85, ""attack"": 80, ""defense"": 65, ""special-attack"": 90, ""special-defense"": 65}","Long Neck Pokémon","Girafarig’s rear head contains a tiny brain that is too small for
+thinking. However, the rear head doesn’t need to sleep, so it
+can keep watch over its surroundings 24 hours a day."
+204,"Pineco","[""bug""]",6.00,72.00,"[""overcoat"", ""sturdy""]","[""bug""]","{""hp"": 50, ""speed"": 15, ""attack"": 65, ""defense"": 90, ""special-attack"": 35, ""special-defense"": 35}","Bagworm Pokémon","Pineco hangs from a tree branch and patiently waits for prey to
+come along. If the Pokémon is disturbed while eating by
+someone shaking its tree, it drops down to the ground and
+explodes with no warning."
+205,"Forretress","[""steel"", ""bug""]",12.00,1258.00,"[""overcoat"", ""sturdy""]","[""bug""]","{""hp"": 75, ""speed"": 40, ""attack"": 90, ""defense"": 140, ""special-attack"": 60, ""special-defense"": 60}","Bagworm Pokémon","Forretress conceals itself inside its hardened steel shell.
+The shell is opened when the Pokémon is catching prey,
+but it does so at such a quick pace that the shell’s inside
+cannot be seen."
+206,"Dunsparce","[""normal""]",15.00,140.00,"[""rattled"", ""run-away"", ""serene-grace""]","[""ground""]","{""hp"": 100, ""speed"": 45, ""attack"": 70, ""defense"": 70, ""special-attack"": 65, ""special-defense"": 65}","Land Snake Pokémon","Dunsparce has a drill for its tail. It uses this tail to burrow into
+the ground backward. This Pokémon is known to make its
+nest in complex shapes deep under the ground."
+207,"Gligar","[""flying"", ""ground""]",11.00,648.00,"[""immunity"", ""sand-veil"", ""hyper-cutter""]","[""bug""]","{""hp"": 65, ""speed"": 85, ""attack"": 75, ""defense"": 105, ""special-attack"": 35, ""special-defense"": 65}","Fly Scorpion Pokémon","Gligar glides through the air without a sound as if it were
+sliding. This Pokémon hangs on to the face of its foe using
+its clawed hind legs and the large pincers on its forelegs, then
+injects the prey with its poison barb."
+208,"Steelix","[""ground"", ""steel""]",92.00,4000.00,"[""sheer-force"", ""sturdy"", ""rock-head""]","[""mineral""]","{""hp"": 75, ""speed"": 30, ""attack"": 85, ""defense"": 200, ""special-attack"": 55, ""special-defense"": 65}","Iron Snake Pokémon","Steelix lives even further underground than Onix.
+This Pokémon is known to dig toward the earth’s core.
+There are records of this Pokémon reaching a depth of
+over six-tenths of a mile underground."
+209,"Snubbull","[""fairy""]",6.00,78.00,"[""rattled"", ""run-away"", ""intimidate""]","[""fairy"", ""ground""]","{""hp"": 60, ""speed"": 30, ""attack"": 80, ""defense"": 50, ""special-attack"": 40, ""special-defense"": 40}","Fairy Pokémon","Its growls make its opponents uneasy. This
+laid-back Pokémon tends to sleep half the day."
+210,"Granbull","[""fairy""]",14.00,487.00,"[""rattled"", ""quick-feet"", ""intimidate""]","[""fairy"", ""ground""]","{""hp"": 90, ""speed"": 45, ""attack"": 120, ""defense"": 75, ""special-attack"": 60, ""special-defense"": 60}","Fairy Pokémon","More timid than Snubbull, this Pokémon is doted
+on by young people amused at the contrast
+between its looks and its attitude."
+211,"Qwilfish","[""poison"", ""water""]",5.00,39.00,"[""intimidate"", ""swift-swim"", ""poison-point""]","[""water2""]","{""hp"": 65, ""speed"": 85, ""attack"": 95, ""defense"": 85, ""special-attack"": 55, ""special-defense"": 55}","Balloon Pokémon","Qwilfish sucks in water, inflating itself. This Pokémon
+uses the pressure of the water it swallowed to shoot toxic
+quills all at once from all over its body. It finds swimming
+somewhat challenging."
+212,"Scizor","[""steel"", ""bug""]",18.00,1180.00,"[""light-metal"", ""technician"", ""swarm""]","[""bug""]","{""hp"": 70, ""speed"": 65, ""attack"": 130, ""defense"": 100, ""special-attack"": 55, ""special-defense"": 80}","Pincer Pokémon","Once it has identified an enemy, this Pokémon
+smashes it mercilessly with pincers hard
+as steel."
+213,"Shuckle","[""rock"", ""bug""]",6.00,205.00,"[""contrary"", ""gluttony"", ""sturdy""]","[""bug""]","{""hp"": 20, ""speed"": 5, ""attack"": 10, ""defense"": 230, ""special-attack"": 10, ""special-defense"": 230}","Mold Pokémon","Shuckle quietly hides itself under rocks, keeping its body
+concealed inside its hard shell while eating berries it has
+stored away. The berries mix with its body fluids to become
+a juice."
+214,"Heracross","[""fighting"", ""bug""]",15.00,540.00,"[""moxie"", ""guts"", ""swarm""]","[""bug""]","{""hp"": 80, ""speed"": 85, ""attack"": 125, ""defense"": 75, ""special-attack"": 40, ""special-defense"": 95}","Single Horn Pokémon","Heracross has sharp claws on its feet. These are planted
+firmly into the ground or the bark of a tree, giving the
+Pokémon a secure and solid footing to forcefully fling away
+foes with its proud horn."
+215,"Sneasel","[""ice"", ""dark""]",9.00,280.00,"[""pickpocket"", ""keen-eye"", ""inner-focus""]","[""ground""]","{""hp"": 55, ""speed"": 115, ""attack"": 95, ""defense"": 55, ""special-attack"": 35, ""special-defense"": 75}","Sharp Claw Pokémon","It uses its claws to poke holes in eggs so it can
+slurp out the insides. Breeders consider it a
+scourge and will drive it away or eradicate it."
+216,"Teddiursa","[""normal""]",6.00,88.00,"[""honey-gather"", ""quick-feet"", ""pickup""]","[""ground""]","{""hp"": 60, ""speed"": 40, ""attack"": 80, ""defense"": 50, ""special-attack"": 50, ""special-defense"": 50}","Little Bear Pokémon","This Pokémon likes to lick its palms that are sweetened by
+being soaked in honey. Teddiursa concocts its own honey
+by blending fruits and pollen collected by Beedrill."
+217,"Ursaring","[""normal""]",18.00,1258.00,"[""unnerve"", ""quick-feet"", ""guts""]","[""ground""]","{""hp"": 90, ""speed"": 55, ""attack"": 130, ""defense"": 75, ""special-attack"": 75, ""special-defense"": 75}","Hibernator Pokémon","In the forests inhabited by Ursaring, it is said that there are
+many streams and towering trees where they gather food. This
+Pokémon walks through its forest gathering food every day."
+218,"Slugma","[""fire""]",7.00,350.00,"[""weak-armor"", ""flame-body"", ""magma-armor""]","[""indeterminate""]","{""hp"": 40, ""speed"": 20, ""attack"": 40, ""defense"": 40, ""special-attack"": 70, ""special-defense"": 40}","Lava Pokémon","Slugma does not have any blood in its body. Instead, intensely
+hot magma circulates throughout this Pokémon’s body,
+carrying essential nutrients and oxygen to its organs."
+219,"Magcargo","[""rock"", ""fire""]",8.00,550.00,"[""weak-armor"", ""flame-body"", ""magma-armor""]","[""indeterminate""]","{""hp"": 60, ""speed"": 30, ""attack"": 50, ""defense"": 120, ""special-attack"": 90, ""special-defense"": 80}","Lava Pokémon","Magcargo’s body temperature is approximately
+18,000 degrees Fahrenheit. Water is vaporized on contact.
+If this Pokémon is caught in the rain, the raindrops instantly
+turn into steam, cloaking the area in a thick fog."
+220,"Swinub","[""ground"", ""ice""]",4.00,65.00,"[""thick-fat"", ""snow-cloak"", ""oblivious""]","[""ground""]","{""hp"": 50, ""speed"": 50, ""attack"": 50, ""defense"": 40, ""special-attack"": 30, ""special-defense"": 30}","Pig Pokémon","Swinub roots for food by rubbing its snout against the ground.
+Its favorite food is a mushroom that grows under the cover of
+dead grass. This Pokémon occasionally roots out hot springs."
+221,"Piloswine","[""ground"", ""ice""]",11.00,558.00,"[""thick-fat"", ""snow-cloak"", ""oblivious""]","[""ground""]","{""hp"": 100, ""speed"": 50, ""attack"": 100, ""defense"": 80, ""special-attack"": 60, ""special-defense"": 60}","Swine Pokémon","Piloswine is covered by a thick coat of long hair that enables
+it to endure the freezing cold. This Pokémon uses its tusks to
+dig up food that has been buried under ice."
+222,"Corsola","[""rock"", ""water""]",6.00,50.00,"[""regenerator"", ""natural-cure"", ""hustle""]","[""water3"", ""water1""]","{""hp"": 65, ""speed"": 35, ""attack"": 55, ""defense"": 95, ""special-attack"": 65, ""special-defense"": 95}","Coral Pokémon","Pursued by Mareanie for the branches on its
+head, this Pokémon will sometimes snap its own
+branches off as a diversion while it escapes."
+223,"Remoraid","[""water""]",6.00,120.00,"[""moody"", ""sniper"", ""hustle""]","[""water2"", ""water1""]","{""hp"": 35, ""speed"": 65, ""attack"": 65, ""defense"": 35, ""special-attack"": 65, ""special-defense"": 35}","Jet Pokémon","Remoraid sucks in water, then expels it at high velocity using
+its abdominal muscles to shoot down flying prey. When
+evolution draws near, this Pokémon travels downstream
+from rivers."
+224,"Octillery","[""water""]",9.00,285.00,"[""moody"", ""sniper"", ""suction-cups""]","[""water2"", ""water1""]","{""hp"": 75, ""speed"": 45, ""attack"": 105, ""defense"": 75, ""special-attack"": 105, ""special-defense"": 75}","Jet Pokémon","Octillery grabs onto its foe using its tentacles. This Pokémon
+tries to immobilize it before delivering the finishing blow. If the
+foe turns out to be too strong, Octillery spews ink to escape."
+225,"Delibird","[""flying"", ""ice""]",9.00,160.00,"[""insomnia"", ""hustle"", ""vital-spirit""]","[""ground"", ""water1""]","{""hp"": 45, ""speed"": 75, ""attack"": 55, ""defense"": 45, ""special-attack"": 65, ""special-defense"": 45}","Delivery Pokémon","It has a generous habit of sharing its food with
+people and Pokémon, so it’s always scrounging
+around for more food."
+226,"Mantine","[""flying"", ""water""]",21.00,2200.00,"[""water-veil"", ""water-absorb"", ""swift-swim""]","[""water1""]","{""hp"": 85, ""speed"": 70, ""attack"": 40, ""defense"": 70, ""special-attack"": 80, ""special-defense"": 140}","Kite Pokémon","On sunny days, schools of Mantine can be seen elegantly
+leaping over the sea’s waves. This Pokémon is not bothered
+by the Remoraid that hitches rides."
+227,"Skarmory","[""flying"", ""steel""]",17.00,505.00,"[""weak-armor"", ""sturdy"", ""keen-eye""]","[""flying""]","{""hp"": 65, ""speed"": 70, ""attack"": 80, ""defense"": 140, ""special-attack"": 40, ""special-defense"": 70}","Armor Bird Pokémon","Its metal body is sturdy, but it does rust rather
+easily. So on rainy days, this Pokémon prefers
+to stay put in its nest."
+228,"Houndour","[""fire"", ""dark""]",6.00,108.00,"[""unnerve"", ""flash-fire"", ""early-bird""]","[""ground""]","{""hp"": 45, ""speed"": 65, ""attack"": 60, ""defense"": 30, ""special-attack"": 80, ""special-defense"": 50}","Dark Pokémon","Houndour hunt as a coordinated pack. They communicate
+with each other using a variety of cries to corner their prey.
+This Pokémon’s remarkable teamwork is unparalleled."
+229,"Houndoom","[""fire"", ""dark""]",14.00,350.00,"[""unnerve"", ""flash-fire"", ""early-bird""]","[""ground""]","{""hp"": 75, ""speed"": 95, ""attack"": 90, ""defense"": 50, ""special-attack"": 110, ""special-defense"": 80}","Dark Pokémon","In a Houndoom pack, the one with its horns raked sharply
+toward the back serves a leadership role. These Pokémon
+choose their leader by fighting among themselves."
+230,"Kingdra","[""dragon"", ""water""]",18.00,1520.00,"[""damp"", ""sniper"", ""swift-swim""]","[""dragon"", ""water1""]","{""hp"": 75, ""speed"": 85, ""attack"": 95, ""defense"": 95, ""special-attack"": 95, ""special-defense"": 95}","Dragon Pokémon","Kingdra sleeps on the seafloor where it is otherwise devoid
+of life. When a storm arrives, the Pokémon is said to awaken
+and wander about in search of prey."
+231,"Phanpy","[""ground""]",5.00,335.00,"[""sand-veil"", ""pickup""]","[""ground""]","{""hp"": 90, ""speed"": 40, ""attack"": 60, ""defense"": 60, ""special-attack"": 40, ""special-defense"": 40}","Long Nose Pokémon","Phanpy uses its long nose to shower itself. When others
+gather around, they thoroughly douse each other with water.
+These Pokémon can be seen drying their soaking-wet
+bodies at the edge of water."
+232,"Donphan","[""ground""]",11.00,1200.00,"[""sand-veil"", ""sturdy""]","[""ground""]","{""hp"": 90, ""speed"": 50, ""attack"": 120, ""defense"": 120, ""special-attack"": 60, ""special-defense"": 60}","Armor Pokémon","If Donphan were to tackle with its hard body, even a house
+could be destroyed. Using its massive strength, the Pokémon
+helps clear rock and mud slides that block mountain trails."
+233,"Porygon2","[""normal""]",6.00,325.00,"[""analytic"", ""download"", ""trace""]","[""mineral""]","{""hp"": 85, ""speed"": 60, ""attack"": 80, ""defense"": 90, ""special-attack"": 105, ""special-defense"": 95}","Virtual Pokémon","Porygon was updated to a new version in
+readiness for planetary development. But that
+dream remains unrealized as yet."
+234,"Stantler","[""normal""]",14.00,712.00,"[""sap-sipper"", ""frisk"", ""intimidate""]","[""ground""]","{""hp"": 73, ""speed"": 85, ""attack"": 95, ""defense"": 62, ""special-attack"": 85, ""special-defense"": 65}","Big Horn Pokémon","Stantler’s magnificent antlers were traded at high prices as
+works of art. As a result, this Pokémon was hunted close to
+extinction by those who were after the priceless antlers."
+235,"Smeargle","[""normal""]",12.00,580.00,"[""moody"", ""technician"", ""own-tempo""]","[""ground""]","{""hp"": 55, ""speed"": 75, ""attack"": 20, ""defense"": 35, ""special-attack"": 20, ""special-defense"": 45}","Painter Pokémon","It draws symbols all over the place to mark its
+territory. In towns with many Smeargle, the walls
+are covered in graffiti."
+236,"Tyrogue","[""fighting""]",7.00,210.00,"[""vital-spirit"", ""steadfast"", ""guts""]","[""no-eggs""]","{""hp"": 35, ""speed"": 35, ""attack"": 35, ""defense"": 35, ""special-attack"": 35, ""special-defense"": 35}","Scuffle Pokémon","Tyrogue becomes stressed out if it does not get to train every
+day. When raising this Pokémon, the Trainer must establish
+and uphold various training methods."
+237,"Hitmontop","[""fighting""]",14.00,480.00,"[""steadfast"", ""technician"", ""intimidate""]","[""humanshape""]","{""hp"": 50, ""speed"": 70, ""attack"": 95, ""defense"": 95, ""special-attack"": 35, ""special-defense"": 110}","Handstand Pokémon","Hitmontop spins on its head at high speed, all the while
+delivering kicks. This technique is a remarkable mix of both
+offense and defense at the same time. The Pokémon travels
+faster spinning than it does walking."
+238,"Smoochum","[""psychic"", ""ice""]",4.00,60.00,"[""hydration"", ""forewarn"", ""oblivious""]","[""no-eggs""]","{""hp"": 45, ""speed"": 65, ""attack"": 30, ""defense"": 15, ""special-attack"": 85, ""special-defense"": 65}","Kiss Pokémon","Smoochum actively runs about, but also falls quite often.
+Whenever the chance arrives, it will look for its reflection to
+make sure its face hasn’t become dirty."
+239,"Elekid","[""electric""]",6.00,235.00,"[""vital-spirit"", ""static""]","[""no-eggs""]","{""hp"": 45, ""speed"": 95, ""attack"": 63, ""defense"": 37, ""special-attack"": 65, ""special-defense"": 55}","Electric Pokémon","This Pokémon is constantly fighting with
+Togedemaru that try to steal its electricity.
+It’s a pretty even match."
+240,"Magby","[""fire""]",7.00,214.00,"[""vital-spirit"", ""flame-body""]","[""no-eggs""]","{""hp"": 45, ""speed"": 83, ""attack"": 75, ""defense"": 37, ""special-attack"": 70, ""special-defense"": 55}","Live Coal Pokémon","A famous potter lives with a Magby.
+Apparently its soft flames produce fine works."
+241,"Miltank","[""normal""]",12.00,755.00,"[""sap-sipper"", ""scrappy"", ""thick-fat""]","[""ground""]","{""hp"": 95, ""speed"": 100, ""attack"": 80, ""defense"": 105, ""special-attack"": 40, ""special-defense"": 70}","Milk Cow Pokémon","Most people raise it for its milk, but it’s quite
+tough and strong, so it’s also well suited
+for battle."
+242,"Blissey","[""normal""]",15.00,468.00,"[""healer"", ""serene-grace"", ""natural-cure""]","[""fairy""]","{""hp"": 255, ""speed"": 55, ""attack"": 10, ""defense"": 10, ""special-attack"": 75, ""special-defense"": 135}","Happiness Pokémon","Its fluffy fur coat acts as a sensor, enabling it to
+read the feelings of people and Pokémon."
+243,"Raikou","[""electric""]",19.00,1780.00,"[""inner-focus"", ""pressure""]","[""no-eggs""]","{""hp"": 90, ""speed"": 115, ""attack"": 85, ""defense"": 75, ""special-attack"": 115, ""special-defense"": 100}","Thunder Pokémon","Raikou embodies the speed of lightning. The roars of
+this Pokémon send shock waves shuddering through the
+air and shake the ground as if lightning bolts had come
+crashing down."
+244,"Entei","[""fire""]",21.00,1980.00,"[""inner-focus"", ""pressure""]","[""no-eggs""]","{""hp"": 115, ""speed"": 100, ""attack"": 115, ""defense"": 85, ""special-attack"": 90, ""special-defense"": 75}","Volcano Pokémon","Entei embodies the passion of magma. This Pokémon is
+thought to have been born in the eruption of a volcano.
+It sends up massive bursts of fire that utterly consume all
+that they touch."
+245,"Suicune","[""water""]",20.00,1870.00,"[""inner-focus"", ""pressure""]","[""no-eggs""]","{""hp"": 100, ""speed"": 85, ""attack"": 75, ""defense"": 115, ""special-attack"": 90, ""special-defense"": 115}","Aurora Pokémon","Suicune embodies the compassion of a pure spring of water.
+It runs across the land with gracefulness. This Pokémon has
+the power to purify dirty water."
+246,"Larvitar","[""ground"", ""rock""]",6.00,720.00,"[""sand-veil"", ""guts""]","[""monster""]","{""hp"": 50, ""speed"": 41, ""attack"": 64, ""defense"": 50, ""special-attack"": 45, ""special-defense"": 50}","Rock Skin Pokémon","Larvitar is born deep under the ground. To come up to the
+surface, this Pokémon must eat its way through the soil above.
+Until it does so, Larvitar cannot see its parents."
+247,"Pupitar","[""ground"", ""rock""]",12.00,1520.00,"[""shed-skin""]","[""monster""]","{""hp"": 70, ""speed"": 51, ""attack"": 84, ""defense"": 70, ""special-attack"": 65, ""special-defense"": 70}","Hard Shell Pokémon","Pupitar creates a gas inside its body that it compresses and
+forcefully ejects to propel itself like a jet. The body is very
+durable—it avoids damage even if it hits solid steel."
+248,"Tyranitar","[""dark"", ""rock""]",20.00,2020.00,"[""unnerve"", ""sand-stream""]","[""monster""]","{""hp"": 100, ""speed"": 61, ""attack"": 134, ""defense"": 110, ""special-attack"": 95, ""special-defense"": 100}","Armor Pokémon","Tyranitar is so overwhelmingly powerful, it can bring down a
+whole mountain to make its nest. This Pokémon wanders about
+in mountains seeking new opponents to fight."
+249,"Lugia","[""flying"", ""psychic""]",52.00,2160.00,"[""multiscale"", ""pressure""]","[""no-eggs""]","{""hp"": 106, ""speed"": 110, ""attack"": 90, ""defense"": 130, ""special-attack"": 90, ""special-defense"": 154}","Diving Pokémon","Lugia’s wings pack devastating power—a light fluttering of its
+wings can blow apart regular houses. As a result, this
+Pokémon chooses to live out of sight deep under the sea."
+250,"Ho-Oh","[""flying"", ""fire""]",38.00,1990.00,"[""regenerator"", ""pressure""]","[""no-eggs""]","{""hp"": 106, ""speed"": 90, ""attack"": 130, ""defense"": 90, ""special-attack"": 110, ""special-defense"": 154}","Rainbow Pokémon","Ho-Oh’s feathers glow in seven colors depending on the angle
+at which they are struck by light. These feathers are said to
+bring happiness to the bearers. This Pokémon is said to live at
+the foot of a rainbow."
+251,"Celebi","[""grass"", ""psychic""]",6.00,50.00,"[""natural-cure""]","[""no-eggs""]","{""hp"": 100, ""speed"": 100, ""attack"": 100, ""defense"": 100, ""special-attack"": 100, ""special-defense"": 100}","Time Travel Pokémon","This Pokémon came from the future by crossing over time.
+It is thought that so long as Celebi appears, a bright and
+shining future awaits us."
+252,"Treecko","[""grass""]",5.00,50.00,"[""unburden"", ""overgrow""]","[""dragon"", ""monster""]","{""hp"": 40, ""speed"": 70, ""attack"": 45, ""defense"": 35, ""special-attack"": 65, ""special-defense"": 55}","Wood Gecko Pokémon","Treecko is cool, calm, and collected—it never panics under
+any situation. If a bigger foe were to glare at this Pokémon,
+it would glare right back without conceding an inch of ground."
+253,"Grovyle","[""grass""]",9.00,216.00,"[""unburden"", ""overgrow""]","[""dragon"", ""monster""]","{""hp"": 50, ""speed"": 95, ""attack"": 65, ""defense"": 45, ""special-attack"": 85, ""special-defense"": 65}","Wood Gecko Pokémon","This Pokémon adeptly flies from branch to branch in trees.
+In a forest, no Pokémon can ever hope to catch a fleeing
+Grovyle however fast they may be."
+254,"Sceptile","[""grass""]",17.00,522.00,"[""unburden"", ""overgrow""]","[""dragon"", ""monster""]","{""hp"": 70, ""speed"": 120, ""attack"": 85, ""defense"": 65, ""special-attack"": 105, ""special-defense"": 85}","Forest Pokémon","Sceptile has seeds growing on its back. They are said to be
+bursting with nutrients that revitalize trees. This Pokémon
+raises the trees in a forest with loving care."
+255,"Torchic","[""fire""]",4.00,25.00,"[""speed-boost"", ""blaze""]","[""ground""]","{""hp"": 45, ""speed"": 45, ""attack"": 60, ""defense"": 40, ""special-attack"": 70, ""special-defense"": 50}","Chick Pokémon","Torchic has a place inside its body where it keeps its flame.
+Give it a hug—it will be glowing with warmth. This Pokémon is
+covered all over by a fluffy coat of down."
+256,"Combusken","[""fighting"", ""fire""]",9.00,195.00,"[""speed-boost"", ""blaze""]","[""ground""]","{""hp"": 60, ""speed"": 55, ""attack"": 85, ""defense"": 60, ""special-attack"": 85, ""special-defense"": 60}","Young Fowl Pokémon","Combusken battles with the intensely hot flames it spews from
+its beak and with outstandingly destructive kicks. This
+Pokémon’s cry is very loud and distracting."
+257,"Blaziken","[""fighting"", ""fire""]",19.00,520.00,"[""speed-boost"", ""blaze""]","[""ground""]","{""hp"": 80, ""speed"": 80, ""attack"": 120, ""defense"": 70, ""special-attack"": 110, ""special-defense"": 70}","Blaze Pokémon","Blaziken has incredibly strong legs—it can easily clear a
+30-story building in one leap. This Pokémon’s blazing punches
+leave its foes scorched and blackened."
+258,"Mudkip","[""water""]",4.00,76.00,"[""damp"", ""torrent""]","[""water1"", ""monster""]","{""hp"": 50, ""speed"": 40, ""attack"": 70, ""defense"": 50, ""special-attack"": 50, ""special-defense"": 50}","Mud Fish Pokémon","In water, Mudkip breathes using the gills on its cheeks. If it is
+faced with a tight situation in battle, this Pokémon will unleash
+its amazing power—it can crush rocks bigger than itself."
+259,"Marshtomp","[""ground"", ""water""]",7.00,280.00,"[""damp"", ""torrent""]","[""water1"", ""monster""]","{""hp"": 70, ""speed"": 50, ""attack"": 85, ""defense"": 70, ""special-attack"": 60, ""special-defense"": 70}","Mud Fish Pokémon","Marshtomp is much faster at traveling through mud than it is at
+swimming. This Pokémon’s hindquarters exhibit obvious
+development, giving it the ability to walk on just its hind legs."
+260,"Swampert","[""ground"", ""water""]",15.00,819.00,"[""damp"", ""torrent""]","[""water1"", ""monster""]","{""hp"": 100, ""speed"": 60, ""attack"": 110, ""defense"": 90, ""special-attack"": 85, ""special-defense"": 90}","Mud Fish Pokémon","Swampert predicts storms by sensing subtle differences in the
+sounds of waves and tidal winds with its fins. If a storm is
+approaching, it piles up boulders to protect itself."
+261,"Poochyena","[""dark""]",5.00,136.00,"[""rattled"", ""quick-feet"", ""run-away""]","[""ground""]","{""hp"": 35, ""speed"": 35, ""attack"": 55, ""defense"": 35, ""special-attack"": 30, ""special-defense"": 30}","Bite Pokémon","Poochyena is an omnivore—it will eat anything. A distinguishing
+feature is how large its fangs are compared to its body. This
+Pokémon tries to intimidate its foes by making the hair on its
+tail bristle out."
+262,"Mightyena","[""dark""]",10.00,370.00,"[""moxie"", ""quick-feet"", ""intimidate""]","[""ground""]","{""hp"": 70, ""speed"": 70, ""attack"": 90, ""defense"": 70, ""special-attack"": 60, ""special-defense"": 60}","Bite Pokémon","Mightyena travel and act as a pack in the wild. The memory
+of its life in the wild compels the Pokémon to obey only
+those Trainers that it recognizes to possess superior skill."
+263,"Zigzagoon","[""normal""]",4.00,175.00,"[""quick-feet"", ""gluttony"", ""pickup""]","[""ground""]","{""hp"": 38, ""speed"": 60, ""attack"": 30, ""defense"": 41, ""special-attack"": 30, ""special-defense"": 41}","Tiny Raccoon Pokémon","The hair on Zigzagoon’s back is bristly. It rubs the hard back
+hair against trees to leave its territorial markings. This Pokémon
+may play dead to fool foes in battle."
+264,"Linoone","[""normal""]",5.00,325.00,"[""quick-feet"", ""gluttony"", ""pickup""]","[""ground""]","{""hp"": 78, ""speed"": 100, ""attack"": 70, ""defense"": 61, ""special-attack"": 50, ""special-defense"": 61}","Rushing Pokémon","When hunting, Linoone will make a beeline straight for the
+prey at a full run. While this Pokémon is capable of topping
+60 mph, it has to come to a screeching halt before it can turn."
+265,"Wurmple","[""bug""]",3.00,36.00,"[""run-away"", ""shield-dust""]","[""bug""]","{""hp"": 45, ""speed"": 20, ""attack"": 45, ""defense"": 35, ""special-attack"": 20, ""special-defense"": 30}","Worm Pokémon","Wurmple is targeted by Swellow as prey. This Pokémon
+will try to resist by pointing the spikes on its rear at the
+attacking predator. It will weaken the foe by leaking poison
+from the spikes."
+266,"Silcoon","[""bug""]",6.00,100.00,"[""shed-skin""]","[""bug""]","{""hp"": 50, ""speed"": 15, ""attack"": 35, ""defense"": 55, ""special-attack"": 25, ""special-defense"": 25}","Cocoon Pokémon","Silcoon was thought to endure hunger and not consume
+anything before its evolution. However, it is now thought
+that this Pokémon slakes its thirst by drinking rainwater
+that collects on its silk."
+267,"Beautifly","[""flying"", ""bug""]",10.00,284.00,"[""rivalry"", ""swarm""]","[""bug""]","{""hp"": 60, ""speed"": 65, ""attack"": 70, ""defense"": 50, ""special-attack"": 100, ""special-defense"": 50}","Butterfly Pokémon","Beautifly has a long mouth like a coiled needle, which is very
+convenient for collecting pollen from flowers. This Pokémon
+rides the spring winds as it flits around gathering pollen."
+268,"Cascoon","[""bug""]",7.00,115.00,"[""shed-skin""]","[""bug""]","{""hp"": 50, ""speed"": 15, ""attack"": 35, ""defense"": 55, ""special-attack"": 25, ""special-defense"": 25}","Cocoon Pokémon","If it is attacked, Cascoon remains motionless however badly it
+may be hurt. It does so because if it were to move, its body
+would be weak upon evolution. This Pokémon will also not
+forget the pain it endured."
+269,"Dustox","[""poison"", ""bug""]",12.00,316.00,"[""compound-eyes"", ""shield-dust""]","[""bug""]","{""hp"": 60, ""speed"": 65, ""attack"": 50, ""defense"": 70, ""special-attack"": 50, ""special-defense"": 90}","Poison Moth Pokémon","When Dustox flaps its wings, a fine dust is scattered all over.
+This dust is actually a powerful poison that will even make a
+pro wrestler sick. This Pokémon searches for food using its
+antennae like radar."
+270,"Lotad","[""grass"", ""water""]",5.00,26.00,"[""own-tempo"", ""rain-dish"", ""swift-swim""]","[""plant"", ""water1""]","{""hp"": 40, ""speed"": 30, ""attack"": 30, ""defense"": 30, ""special-attack"": 40, ""special-defense"": 50}","Water Weed Pokémon","Lotad is said to have dwelled on land before. However, this
+Pokémon is thought to have returned to water because the
+leaf on its head grew large and heavy. It now lives by floating
+atop the water."
+271,"Lombre","[""grass"", ""water""]",12.00,325.00,"[""own-tempo"", ""rain-dish"", ""swift-swim""]","[""plant"", ""water1""]","{""hp"": 60, ""speed"": 50, ""attack"": 50, ""defense"": 50, ""special-attack"": 60, ""special-defense"": 70}","Jolly Pokémon","Lombre’s entire body is covered by a slippery, slimy film.
+It feels horribly unpleasant to be touched by this Pokémon’s
+hands. Lombre is often mistaken for a human child."
+272,"Ludicolo","[""grass"", ""water""]",15.00,550.00,"[""own-tempo"", ""rain-dish"", ""swift-swim""]","[""plant"", ""water1""]","{""hp"": 80, ""speed"": 70, ""attack"": 70, ""defense"": 70, ""special-attack"": 90, ""special-defense"": 100}","Carefree Pokémon","Upon hearing an upbeat and cheerful rhythm, the cells in
+Ludicolo’s body become very energetic and active. Even
+in battle, this Pokémon will exhibit an amazing amount
+of power."
+273,"Seedot","[""grass""]",5.00,40.00,"[""pickpocket"", ""early-bird"", ""chlorophyll""]","[""plant"", ""ground""]","{""hp"": 40, ""speed"": 30, ""attack"": 40, ""defense"": 50, ""special-attack"": 30, ""special-defense"": 30}","Acorn Pokémon","Seedot looks exactly like an acorn when it is dangling from a
+tree branch. It startles other Pokémon by suddenly moving.
+This Pokémon polishes its body once a day using leaves."
+274,"Nuzleaf","[""dark"", ""grass""]",10.00,280.00,"[""pickpocket"", ""early-bird"", ""chlorophyll""]","[""plant"", ""ground""]","{""hp"": 70, ""speed"": 60, ""attack"": 70, ""defense"": 40, ""special-attack"": 60, ""special-defense"": 40}","Wily Pokémon","This Pokémon pulls out the leaf on its head and makes a flute
+with it. The sound of Nuzleaf’s flute strikes fear and uncertainty
+in the hearts of people lost in a forest."
+275,"Shiftry","[""dark"", ""grass""]",13.00,596.00,"[""pickpocket"", ""early-bird"", ""chlorophyll""]","[""plant"", ""ground""]","{""hp"": 90, ""speed"": 80, ""attack"": 100, ""defense"": 60, ""special-attack"": 90, ""special-defense"": 60}","Wicked Pokémon","Shiftry’s large fans generate awesome gusts of wind at a
+speed close to 100 feet per second. The whipped-up wind
+blows anything away. This Pokémon chooses to live quietly
+deep in forests."
+276,"Taillow","[""flying"", ""normal""]",3.00,23.00,"[""scrappy"", ""guts""]","[""flying""]","{""hp"": 40, ""speed"": 85, ""attack"": 55, ""defense"": 30, ""special-attack"": 30, ""special-defense"": 30}","Tiny Swallow Pokémon","Taillow is young—it has only just left its nest. As a result,
+it sometimes becomes lonesome and cries at night.
+This Pokémon feeds on Wurmple that live in forests."
+277,"Swellow","[""flying"", ""normal""]",7.00,198.00,"[""scrappy"", ""guts""]","[""flying""]","{""hp"": 60, ""speed"": 125, ""attack"": 85, ""defense"": 60, ""special-attack"": 75, ""special-defense"": 50}","Swallow Pokémon","Swellow is very conscientious about the upkeep of its glossy
+wings. Once two Swellow are gathered, they diligently take
+care of cleaning each other’s wings."
+278,"Wingull","[""flying"", ""water""]",6.00,95.00,"[""rain-dish"", ""hydration"", ""keen-eye""]","[""flying"", ""water1""]","{""hp"": 40, ""speed"": 85, ""attack"": 30, ""defense"": 30, ""special-attack"": 55, ""special-defense"": 30}","Seagull Pokémon","Fishermen keep an eye out for Wingull in the
+sky, because wherever they’re circling, the
+ocean is sure to be teeming with fish Pokémon."
+279,"Pelipper","[""flying"", ""water""]",12.00,280.00,"[""rain-dish"", ""drizzle"", ""keen-eye""]","[""flying"", ""water1""]","{""hp"": 60, ""speed"": 65, ""attack"": 50, ""defense"": 100, ""special-attack"": 95, ""special-defense"": 70}","Water Bird Pokémon","Gathering food is the work of young males.
+They store food in their capacious beaks and
+carry it back to others waiting in the nest."
+280,"Ralts","[""fairy"", ""psychic""]",4.00,66.00,"[""telepathy"", ""trace"", ""synchronize""]","[""indeterminate""]","{""hp"": 28, ""speed"": 40, ""attack"": 25, ""defense"": 25, ""special-attack"": 45, ""special-defense"": 35}","Feeling Pokémon","Ralts has the ability to sense the emotions of people. If its
+Trainer is in a cheerful mood, this Pokémon grows cheerful
+and joyous in the same way."
+281,"Kirlia","[""fairy"", ""psychic""]",8.00,202.00,"[""telepathy"", ""trace"", ""synchronize""]","[""indeterminate""]","{""hp"": 38, ""speed"": 50, ""attack"": 35, ""defense"": 35, ""special-attack"": 65, ""special-defense"": 55}","Emotion Pokémon","Kirlia uses the horns on its head to amplify its psychokinetic
+power. When the Pokémon uses its power, the air around it
+becomes distorted, creating mirages of nonexistent scenery."
+282,"Gardevoir","[""fairy"", ""psychic""]",16.00,484.00,"[""telepathy"", ""trace"", ""synchronize""]","[""indeterminate""]","{""hp"": 68, ""speed"": 80, ""attack"": 65, ""defense"": 65, ""special-attack"": 125, ""special-defense"": 115}","Embrace Pokémon","Gardevoir has the psychokinetic power to distort the
+dimensions and create a small black hole. This Pokémon
+will try to protect its Trainer even at the risk of its own life."
+283,"Surskit","[""water"", ""bug""]",5.00,17.00,"[""rain-dish"", ""swift-swim""]","[""bug"", ""water1""]","{""hp"": 40, ""speed"": 65, ""attack"": 30, ""defense"": 32, ""special-attack"": 50, ""special-defense"": 52}","Pond Skater Pokémon","When this Pokémon senses danger, a sweet
+fluid oozes from the tip of its head. The taste
+of it disgusts bird Pokémon."
+284,"Masquerain","[""flying"", ""bug""]",8.00,36.00,"[""unnerve"", ""intimidate""]","[""bug"", ""water1""]","{""hp"": 70, ""speed"": 80, ""attack"": 60, ""defense"": 62, ""special-attack"": 100, ""special-defense"": 82}","Eyeball Pokémon","Its wings and antennae don’t cope well with
+moisture. After a rain, it faces sunward to
+dry off."
+285,"Shroomish","[""grass""]",4.00,45.00,"[""quick-feet"", ""poison-heal"", ""effect-spore""]","[""plant"", ""fairy""]","{""hp"": 60, ""speed"": 35, ""attack"": 40, ""defense"": 60, ""special-attack"": 40, ""special-defense"": 60}","Mushroom Pokémon","If Shroomish senses danger, it shakes its body and scatters
+spores from the top of its head. This Pokémon’s spores are
+so toxic, they make trees and weeds wilt."
+286,"Breloom","[""fighting"", ""grass""]",12.00,392.00,"[""technician"", ""poison-heal"", ""effect-spore""]","[""plant"", ""fairy""]","{""hp"": 60, ""speed"": 70, ""attack"": 130, ""defense"": 80, ""special-attack"": 60, ""special-defense"": 60}","Mushroom Pokémon","The seeds ringing Breloom’s tail are made of hardened toxic
+spores. It is horrible to eat the seeds. Just taking a bite of this
+Pokémon’s seed will cause your stomach to rumble."
+287,"Slakoth","[""normal""]",8.00,240.00,"[""truant""]","[""ground""]","{""hp"": 60, ""speed"": 30, ""attack"": 60, ""defense"": 60, ""special-attack"": 35, ""special-defense"": 35}","Slacker Pokémon","Slakoth’s heart beats just once a minute. Whatever happens,
+it is content to loaf around motionless. It is rare to see this
+Pokémon in motion."
+288,"Vigoroth","[""normal""]",14.00,465.00,"[""vital-spirit""]","[""ground""]","{""hp"": 80, ""speed"": 90, ""attack"": 80, ""defense"": 80, ""special-attack"": 55, ""special-defense"": 55}","Wild Monkey Pokémon","Vigoroth is simply incapable of remaining still. Even when it
+tries to sleep, the blood in its veins grows agitated, compelling
+this Pokémon to run wild throughout the jungle before it can
+settle down."
+289,"Slaking","[""normal""]",20.00,1305.00,"[""truant""]","[""ground""]","{""hp"": 150, ""speed"": 100, ""attack"": 160, ""defense"": 100, ""special-attack"": 95, ""special-defense"": 65}","Lazy Pokémon","Wherever Slaking live, rings of over a yard in diameter appear
+in grassy fields. They are made by the Pokémon as it eats all
+the grass within reach while lying prone on the ground."
+290,"Nincada","[""ground"", ""bug""]",5.00,55.00,"[""run-away"", ""compound-eyes""]","[""bug""]","{""hp"": 31, ""speed"": 40, ""attack"": 45, ""defense"": 90, ""special-attack"": 30, ""special-defense"": 30}","Trainee Pokémon","Nincada lives underground. It uses its sharp claws to carve the
+roots of trees and absorb moisture and nutrients.
+This Pokémon can’t withstand bright sunlight so avoids it."
+291,"Ninjask","[""flying"", ""bug""]",8.00,120.00,"[""infiltrator"", ""speed-boost""]","[""bug""]","{""hp"": 61, ""speed"": 160, ""attack"": 90, ""defense"": 45, ""special-attack"": 50, ""special-defense"": 50}","Ninja Pokémon","If Ninjask is not trained properly, it will refuse to obey
+the Trainer and cry loudly continuously. Because of this
+quality, this Pokémon is said to be one that puts the
+Trainer’s abilities to the test."
+292,"Shedinja","[""ghost"", ""bug""]",8.00,12.00,"[""wonder-guard""]","[""mineral""]","{""hp"": 1, ""speed"": 40, ""attack"": 90, ""defense"": 45, ""special-attack"": 30, ""special-defense"": 30}","Shed Pokémon","Shedinja is a peculiar Pokémon. It seems to appear unsought
+in a Poké Ball after a Nincada evolves. This bizarre Pokémon
+is entirely immobile—it doesn’t even breathe."
+293,"Whismur","[""normal""]",6.00,163.00,"[""rattled"", ""soundproof""]","[""ground"", ""monster""]","{""hp"": 64, ""speed"": 28, ""attack"": 51, ""defense"": 23, ""special-attack"": 51, ""special-defense"": 23}","Whisper Pokémon","Whismur is very timid. If it starts to cry loudly, it becomes
+startled by its own crying and cries even harder. When it finally
+stops crying, the Pokémon goes to sleep, all tired out."
+294,"Loudred","[""normal""]",10.00,405.00,"[""scrappy"", ""soundproof""]","[""ground"", ""monster""]","{""hp"": 84, ""speed"": 48, ""attack"": 71, ""defense"": 43, ""special-attack"": 71, ""special-defense"": 43}","Big Voice Pokémon","Loudred shouts while stamping its feet. After it finishes
+shouting, this Pokémon becomes incapable of hearing
+anything for a while. This is considered to be a weak point."
+295,"Exploud","[""normal""]",15.00,840.00,"[""scrappy"", ""soundproof""]","[""ground"", ""monster""]","{""hp"": 104, ""speed"": 68, ""attack"": 91, ""defense"": 63, ""special-attack"": 91, ""special-defense"": 73}","Loud Noise Pokémon","Exploud communicates its feelings to the others by emitting
+whistle-like sounds from the tubes on its body. This Pokémon
+only raises its voice when it is in battle."
+296,"Makuhita","[""fighting""]",10.00,864.00,"[""sheer-force"", ""guts"", ""thick-fat""]","[""humanshape""]","{""hp"": 72, ""speed"": 25, ""attack"": 60, ""defense"": 30, ""special-attack"": 20, ""special-defense"": 30}","Guts Pokémon","Their daily routine consists of training together
+first thing in the morning, eating and napping in
+the afternoon, and then more training afterward."
+297,"Hariyama","[""fighting""]",23.00,2538.00,"[""sheer-force"", ""guts"", ""thick-fat""]","[""humanshape""]","{""hp"": 144, ""speed"": 50, ""attack"": 120, ""defense"": 60, ""special-attack"": 40, ""special-defense"": 60}","Arm Thrust Pokémon","They love to compare their freakish strength—
+strength enough to send a truck flying with a
+single slap."
+298,"Azurill","[""fairy"", ""normal""]",2.00,20.00,"[""sap-sipper"", ""huge-power"", ""thick-fat""]","[""no-eggs""]","{""hp"": 50, ""speed"": 20, ""attack"": 20, ""defense"": 40, ""special-attack"": 20, ""special-defense"": 40}","Polka Dot Pokémon","Azurill’s tail is large and bouncy. It is packed full of the
+nutrients this Pokémon needs to grow. Azurill can be seen
+bouncing and playing on its big, rubbery tail."
+299,"Nosepass","[""rock""]",10.00,970.00,"[""sand-force"", ""magnet-pull"", ""sturdy""]","[""mineral""]","{""hp"": 30, ""speed"": 30, ""attack"": 45, ""defense"": 135, ""special-attack"": 45, ""special-defense"": 90}","Compass Pokémon","It uses powerful magnetism to drag its prey
+toward it. It’s also been known to pull in metal,
+which it collects and uses to protect itself."
+300,"Skitty","[""normal""]",6.00,110.00,"[""wonder-skin"", ""normalize"", ""cute-charm""]","[""fairy"", ""ground""]","{""hp"": 50, ""speed"": 50, ""attack"": 45, ""defense"": 45, ""special-attack"": 35, ""special-defense"": 35}","Kitten Pokémon","Skitty is known to chase around playfully after its own tail.
+In the wild, this Pokémon lives in holes in the trees of forests.
+It is very popular as a pet because of its adorable looks."
+301,"Delcatty","[""normal""]",11.00,326.00,"[""wonder-skin"", ""normalize"", ""cute-charm""]","[""fairy"", ""ground""]","{""hp"": 70, ""speed"": 90, ""attack"": 65, ""defense"": 65, ""special-attack"": 55, ""special-defense"": 55}","Prim Pokémon","Delcatty sleeps anywhere it wants without keeping a permanent
+nest. If other Pokémon approach it as it sleeps, this Pokémon
+will never fight—it will just move away somewhere else."
+302,"Sableye","[""ghost"", ""dark""]",5.00,110.00,"[""prankster"", ""stall"", ""keen-eye""]","[""humanshape""]","{""hp"": 50, ""speed"": 50, ""attack"": 75, ""defense"": 75, ""special-attack"": 65, ""special-defense"": 65}","Darkness Pokémon","This Pokémon is feared. When its gemstone eyes
+begin to glow with a sinister shine, it’s believed
+that Sableye will steal people’s spirits away."
+303,"Mawile","[""fairy"", ""steel""]",6.00,115.00,"[""sheer-force"", ""intimidate"", ""hyper-cutter""]","[""fairy"", ""ground""]","{""hp"": 50, ""speed"": 50, ""attack"": 85, ""defense"": 85, ""special-attack"": 55, ""special-defense"": 55}","Deceiver Pokémon","Don’t be taken in by this Pokémon’s cute face—it’s very
+dangerous. Mawile fools the foe into letting down its guard,
+then chomps down with its massive jaws. The steel jaws are
+really horns that have been transformed."
+304,"Aron","[""rock"", ""steel""]",4.00,600.00,"[""heavy-metal"", ""rock-head"", ""sturdy""]","[""monster""]","{""hp"": 50, ""speed"": 30, ""attack"": 70, ""defense"": 100, ""special-attack"": 40, ""special-defense"": 40}","Iron Armor Pokémon","Aron has a body of steel. With one all-out charge, this
+Pokémon can demolish even a heavy dump truck.
+The destroyed dump truck then becomes a handy meal
+for the Pokémon."
+305,"Lairon","[""rock"", ""steel""]",9.00,1200.00,"[""heavy-metal"", ""rock-head"", ""sturdy""]","[""monster""]","{""hp"": 60, ""speed"": 40, ""attack"": 90, ""defense"": 140, ""special-attack"": 50, ""special-defense"": 50}","Iron Armor Pokémon","Lairon feeds on iron contained in rocks and water. It makes
+its nest on mountains where iron ore is buried. As a result,
+the Pokémon often clashes with humans mining the iron ore."
+306,"Aggron","[""rock"", ""steel""]",21.00,3600.00,"[""heavy-metal"", ""rock-head"", ""sturdy""]","[""monster""]","{""hp"": 70, ""speed"": 50, ""attack"": 110, ""defense"": 180, ""special-attack"": 60, ""special-defense"": 60}","Iron Armor Pokémon","Aggron is protective of its environment. If its mountain is
+ravaged by a landslide or a fire, this Pokémon will haul
+topsoil to the area, plant trees, and beautifully restore its
+own territory."
+307,"Meditite","[""psychic"", ""fighting""]",6.00,112.00,"[""telepathy"", ""pure-power""]","[""humanshape""]","{""hp"": 30, ""speed"": 60, ""attack"": 40, ""defense"": 55, ""special-attack"": 40, ""special-defense"": 55}","Meditate Pokémon","Meditite heightens its inner energy through meditation.
+It survives on just one berry a day. Minimal eating is another
+aspect of this Pokémon’s training."
+308,"Medicham","[""psychic"", ""fighting""]",13.00,315.00,"[""telepathy"", ""pure-power""]","[""humanshape""]","{""hp"": 60, ""speed"": 80, ""attack"": 60, ""defense"": 75, ""special-attack"": 60, ""special-defense"": 75}","Meditate Pokémon","Through the power of meditation, Medicham developed its
+sixth sense. It gained the ability to use psychokinetic powers.
+This Pokémon is known to meditate for a whole month
+without eating."
+309,"Electrike","[""electric""]",6.00,152.00,"[""minus"", ""lightning-rod"", ""static""]","[""ground""]","{""hp"": 40, ""speed"": 65, ""attack"": 45, ""defense"": 40, ""special-attack"": 65, ""special-defense"": 40}","Lightning Pokémon","Electrike runs faster than the human eye can follow.
+The friction from running is converted into electricity,
+which is then stored in this Pokémon’s fur."
+310,"Manectric","[""electric""]",15.00,402.00,"[""minus"", ""lightning-rod"", ""static""]","[""ground""]","{""hp"": 70, ""speed"": 105, ""attack"": 75, ""defense"": 60, ""special-attack"": 105, ""special-defense"": 60}","Discharge Pokémon","Manectric discharges strong electricity from its mane.
+The mane is used for collecting electricity in the atmosphere.
+This Pokémon creates thunderclouds above its head."
+311,"Plusle","[""electric""]",4.00,42.00,"[""lightning-rod"", ""plus""]","[""fairy""]","{""hp"": 60, ""speed"": 95, ""attack"": 50, ""defense"": 40, ""special-attack"": 85, ""special-defense"": 75}","Cheering Pokémon","When Plusle is cheering on its partner, it flashes with electric
+sparks from all over its body. If its partner loses, this Pokémon
+cries loudly."
+312,"Minun","[""electric""]",4.00,42.00,"[""volt-absorb"", ""minus""]","[""fairy""]","{""hp"": 60, ""speed"": 95, ""attack"": 40, ""defense"": 50, ""special-attack"": 75, ""special-defense"": 85}","Cheering Pokémon","Minun loves to cheer on its partner in battle. It gives off sparks
+from its body while it is doing so. If its partner is in trouble,
+this Pokémon gives off increasing amounts of sparks."
+313,"Volbeat","[""bug""]",7.00,177.00,"[""prankster"", ""swarm"", ""illuminate""]","[""humanshape"", ""bug""]","{""hp"": 65, ""speed"": 85, ""attack"": 73, ""defense"": 75, ""special-attack"": 47, ""special-defense"": 85}","Firefly Pokémon","Volbeat’s tail glows like a lightbulb. With other Volbeat,
+it uses its tail to draw geometric shapes in the night sky.
+This Pokémon loves the sweet aroma given off by Illumise."
+314,"Illumise","[""bug""]",6.00,177.00,"[""prankster"", ""tinted-lens"", ""oblivious""]","[""humanshape"", ""bug""]","{""hp"": 65, ""speed"": 85, ""attack"": 47, ""defense"": 75, ""special-attack"": 73, ""special-defense"": 85}","Firefly Pokémon","Illumise leads a flight of illuminated Volbeat to draw signs in
+the night sky. This Pokémon is said to earn greater respect
+from its peers by composing more complex designs in the sky."
+315,"Roselia","[""poison"", ""grass""]",3.00,20.00,"[""leaf-guard"", ""poison-point"", ""natural-cure""]","[""plant"", ""fairy""]","{""hp"": 50, ""speed"": 65, ""attack"": 60, ""defense"": 45, ""special-attack"": 100, ""special-defense"": 80}","Thorn Pokémon","On extremely rare occasions, a Roselia is said to appear with
+its flowers in unusual colors. The thorns on this Pokémon’s
+head contain a vicious poison."
+316,"Gulpin","[""poison""]",4.00,103.00,"[""gluttony"", ""sticky-hold"", ""liquid-ooze""]","[""indeterminate""]","{""hp"": 70, ""speed"": 40, ""attack"": 43, ""defense"": 53, ""special-attack"": 43, ""special-defense"": 53}","Stomach Pokémon","Most of Gulpin’s body is made up of its stomach—its heart and
+brain are very small in comparison. This Pokémon’s stomach
+contains special enzymes that dissolve anything."
+317,"Swalot","[""poison""]",17.00,800.00,"[""gluttony"", ""sticky-hold"", ""liquid-ooze""]","[""indeterminate""]","{""hp"": 100, ""speed"": 55, ""attack"": 73, ""defense"": 83, ""special-attack"": 73, ""special-defense"": 83}","Poison Bag Pokémon","Swalot has no teeth, so what it eats, it swallows whole, no
+matter what. Its cavernous mouth yawns widely. An automobile
+tire could easily fit inside this Pokémon’s mouth."
+318,"Carvanha","[""dark"", ""water""]",8.00,208.00,"[""speed-boost"", ""rough-skin""]","[""water2""]","{""hp"": 45, ""speed"": 65, ""attack"": 90, ""defense"": 20, ""special-attack"": 65, ""special-defense"": 20}","Savage Pokémon","If they scent the faintest trace of blood, they
+rush to attack en masse. When alone, they’re
+rather cowardly."
+319,"Sharpedo","[""dark"", ""water""]",18.00,888.00,"[""speed-boost"", ""rough-skin""]","[""water2""]","{""hp"": 70, ""speed"": 95, ""attack"": 120, ""defense"": 40, ""special-attack"": 95, ""special-defense"": 40}","Brutal Pokémon","It has a sad history. In the past, its dorsal fin
+was a treasured foodstuff, so this Pokémon
+became a victim of overfishing."
+320,"Wailmer","[""water""]",20.00,1300.00,"[""pressure"", ""oblivious"", ""water-veil""]","[""water2"", ""ground""]","{""hp"": 130, ""speed"": 60, ""attack"": 70, ""defense"": 35, ""special-attack"": 70, ""special-defense"": 35}","Ball Whale Pokémon","It shows off by spraying jets of seawater from
+the nostrils above its eyes. It eats a solid ton of
+Wishiwashi every day."
+321,"Wailord","[""water""]",145.00,3980.00,"[""pressure"", ""oblivious"", ""water-veil""]","[""water2"", ""ground""]","{""hp"": 170, ""speed"": 60, ""attack"": 90, ""defense"": 45, ""special-attack"": 90, ""special-defense"": 45}","Float Whale Pokémon","Its immense size is the reason for its popularity.
+Wailord watching is a favorite sightseeing
+activity in various parts of the world."
+322,"Numel","[""ground"", ""fire""]",7.00,240.00,"[""own-tempo"", ""simple"", ""oblivious""]","[""ground""]","{""hp"": 60, ""speed"": 35, ""attack"": 60, ""defense"": 40, ""special-attack"": 65, ""special-defense"": 45}","Numb Pokémon","Numel stores magma of almost 2,200 degrees Fahrenheit
+within its body. If it gets wet, the magma cools and hardens.
+In that event, the Pokémon’s body grows heavy and its
+movements become sluggish."
+323,"Camerupt","[""ground"", ""fire""]",19.00,2200.00,"[""anger-point"", ""solid-rock"", ""magma-armor""]","[""ground""]","{""hp"": 70, ""speed"": 40, ""attack"": 100, ""defense"": 70, ""special-attack"": 105, ""special-defense"": 75}","Eruption Pokémon","The humps on Camerupt’s back are formed by a transformation
+of its bones. They sometimes blast out molten magma.
+This Pokémon apparently erupts often when it is enraged."
+324,"Torkoal","[""fire""]",5.00,804.00,"[""shell-armor"", ""drought"", ""white-smoke""]","[""ground""]","{""hp"": 70, ""speed"": 20, ""attack"": 85, ""defense"": 140, ""special-attack"": 85, ""special-defense"": 70}","Coal Pokémon","If the fire burning within its shell goes out, it will
+die. Those who wish to raise one in their home
+must always keep something flammable at hand."
+325,"Spoink","[""psychic""]",7.00,306.00,"[""gluttony"", ""own-tempo"", ""thick-fat""]","[""ground""]","{""hp"": 60, ""speed"": 60, ""attack"": 25, ""defense"": 35, ""special-attack"": 70, ""special-defense"": 80}","Bounce Pokémon","Spoink keeps a pearl on top of its head. The pearl functions to
+amplify this Pokémon’s psychokinetic powers. It is therefore on
+a constant search for a bigger pearl."
+326,"Grumpig","[""psychic""]",9.00,715.00,"[""gluttony"", ""own-tempo"", ""thick-fat""]","[""ground""]","{""hp"": 80, ""speed"": 80, ""attack"": 45, ""defense"": 65, ""special-attack"": 90, ""special-defense"": 110}","Manipulate Pokémon","Grumpig uses the black pearls on its body to wield
+its fantastic powers. When it is doing so, it dances bizarrely.
+This Pokémon’s black pearls are valuable as works of art."
+327,"Spinda","[""normal""]",11.00,50.00,"[""contrary"", ""tangled-feet"", ""own-tempo""]","[""humanshape"", ""ground""]","{""hp"": 60, ""speed"": 60, ""attack"": 60, ""defense"": 60, ""special-attack"": 60, ""special-defense"": 60}","Spot Panda Pokémon","Each and every Spinda has a slightly different
+configuration of spots. There are collectors who
+enjoy the tiny differences in their spot patterns."
+328,"Trapinch","[""ground""]",7.00,150.00,"[""sheer-force"", ""arena-trap"", ""hyper-cutter""]","[""bug""]","{""hp"": 45, ""speed"": 10, ""attack"": 100, ""defense"": 45, ""special-attack"": 45, ""special-defense"": 45}","Ant Pit Pokémon","As it digs through the sand, its giant jaws
+crush any rocks that obstruct its path. It builds
+a funnel-shaped nest."
+329,"Vibrava","[""dragon"", ""ground""]",11.00,153.00,"[""levitate""]","[""bug""]","{""hp"": 50, ""speed"": 70, ""attack"": 70, ""defense"": 50, ""special-attack"": 50, ""special-defense"": 50}","Vibration Pokémon","To help make its wings grow, it dissolves
+quantities of prey in its digestive juices and
+guzzles them down every day."
+330,"Flygon","[""dragon"", ""ground""]",20.00,820.00,"[""levitate""]","[""bug""]","{""hp"": 80, ""speed"": 100, ""attack"": 100, ""defense"": 80, ""special-attack"": 80, ""special-defense"": 80}","Mystic Pokémon","This Pokémon hides in the heart of sandstorms
+it creates and seldom appears where people
+can see it."
+331,"Cacnea","[""grass""]",4.00,513.00,"[""water-absorb"", ""sand-veil""]","[""humanshape"", ""plant""]","{""hp"": 50, ""speed"": 35, ""attack"": 85, ""defense"": 40, ""special-attack"": 85, ""special-defense"": 40}","Cactus Pokémon","The more arid and harsh the environment, the more pretty and
+fragrant a flower Cacnea grows. This Pokémon battles by
+wildly swinging its thorny arms."
+332,"Cacturne","[""dark"", ""grass""]",13.00,774.00,"[""water-absorb"", ""sand-veil""]","[""humanshape"", ""plant""]","{""hp"": 70, ""speed"": 55, ""attack"": 115, ""defense"": 60, ""special-attack"": 115, ""special-defense"": 60}","Scarecrow Pokémon","If a traveler is going through a desert in the thick of night,
+Cacturne will follow in a ragtag group. The Pokémon are
+biding their time, waiting for the traveler to tire and become
+incapable of moving."
+333,"Swablu","[""flying"", ""normal""]",4.00,12.00,"[""cloud-nine"", ""natural-cure""]","[""dragon"", ""flying""]","{""hp"": 45, ""speed"": 50, ""attack"": 40, ""defense"": 60, ""special-attack"": 40, ""special-defense"": 75}","Cotton Bird Pokémon","Swablu loves to make things clean. If it spots something dirty,
+it will wipe and polish it with its cottony wings. If its wings
+become dirty, this Pokémon finds a stream and showers itself."
+334,"Altaria","[""flying"", ""dragon""]",11.00,206.00,"[""cloud-nine"", ""natural-cure""]","[""dragon"", ""flying""]","{""hp"": 75, ""speed"": 80, ""attack"": 70, ""defense"": 90, ""special-attack"": 70, ""special-defense"": 105}","Humming Pokémon","Altaria sings in a gorgeous soprano. Its wings are like cotton
+clouds. This Pokémon catches updrafts with its buoyant wings
+and soars way up into the wild blue yonder."
+335,"Zangoose","[""normal""]",13.00,403.00,"[""toxic-boost"", ""immunity""]","[""ground""]","{""hp"": 73, ""speed"": 90, ""attack"": 115, ""defense"": 60, ""special-attack"": 60, ""special-defense"": 60}","Cat Ferret Pokémon","Zangoose usually stays on all fours, but when angered, it gets
+up on its hind legs and extends its claws. This Pokémon shares
+a bitter rivalry with Seviper that dates back over generations."
+336,"Seviper","[""poison""]",27.00,525.00,"[""infiltrator"", ""shed-skin""]","[""dragon"", ""ground""]","{""hp"": 73, ""speed"": 65, ""attack"": 100, ""defense"": 60, ""special-attack"": 100, ""special-defense"": 60}","Fang Snake Pokémon","Seviper’s swordlike tail serves two purposes—it slashes foes
+and douses them with secreted poison. This Pokémon will not
+give up its long-running blood feud with Zangoose."
+337,"Lunatone","[""psychic"", ""rock""]",10.00,1680.00,"[""levitate""]","[""mineral""]","{""hp"": 90, ""speed"": 70, ""attack"": 55, ""defense"": 65, ""special-attack"": 95, ""special-defense"": 85}","Meteorite Pokémon","Lunatone becomes active around the time of the full moon.
+Instead of walking, it moves by floating in midair.
+The Pokémon’s intimidating red eyes cause all those who
+see it to become transfixed with fear."
+338,"Solrock","[""psychic"", ""rock""]",12.00,1540.00,"[""levitate""]","[""mineral""]","{""hp"": 90, ""speed"": 70, ""attack"": 95, ""defense"": 85, ""special-attack"": 55, ""special-defense"": 65}","Meteorite Pokémon","Sunlight is the source of Solrock’s power. It is said to possess
+the ability to read the emotions of others. This Pokémon gives
+off intense heat while rotating its body."
+339,"Barboach","[""ground"", ""water""]",4.00,19.00,"[""hydration"", ""anticipation"", ""oblivious""]","[""water2""]","{""hp"": 50, ""speed"": 60, ""attack"": 48, ""defense"": 43, ""special-attack"": 46, ""special-defense"": 41}","Whiskers Pokémon","Its slippery body is hard to grasp, so much so
+that there are festivals where people compete
+to see how many they can catch barehanded."
+340,"Whiscash","[""ground"", ""water""]",9.00,236.00,"[""hydration"", ""anticipation"", ""oblivious""]","[""water2""]","{""hp"": 110, ""speed"": 60, ""attack"": 78, ""defense"": 73, ""special-attack"": 76, ""special-defense"": 71}","Whiskers Pokémon","Sighting Whiscash leaping from the water
+is believed to herald an earthquake."
+341,"Corphish","[""water""]",6.00,115.00,"[""adaptability"", ""shell-armor"", ""hyper-cutter""]","[""water3"", ""water1""]","{""hp"": 43, ""speed"": 35, ""attack"": 80, ""defense"": 65, ""special-attack"": 50, ""special-defense"": 35}","Ruffian Pokémon","Corphish catches prey with its sharp claws. It has no
+likes or dislikes when it comes to food—it will eat anything.
+This Pokémon has no trouble living in filthy water."
+342,"Crawdaunt","[""dark"", ""water""]",11.00,328.00,"[""adaptability"", ""shell-armor"", ""hyper-cutter""]","[""water3"", ""water1""]","{""hp"": 63, ""speed"": 55, ""attack"": 120, ""defense"": 85, ""special-attack"": 90, ""special-defense"": 55}","Rogue Pokémon","Crawdaunt molts (sheds) its shell regularly. Immediately after
+molting, its shell is soft and tender. Until the shell hardens,
+this Pokémon hides in its streambed burrow to avoid attack
+from its foes."
+343,"Baltoy","[""psychic"", ""ground""]",5.00,215.00,"[""levitate""]","[""mineral""]","{""hp"": 40, ""speed"": 55, ""attack"": 40, ""defense"": 55, ""special-attack"": 40, ""special-defense"": 70}","Clay Doll Pokémon","As soon as it spots others of its kind, Baltoy congregates with
+them and then begins crying noisily in unison. This Pokémon
+sleeps while cleverly balancing itself on its one foot."
+344,"Claydol","[""psychic"", ""ground""]",15.00,1080.00,"[""levitate""]","[""mineral""]","{""hp"": 60, ""speed"": 75, ""attack"": 70, ""defense"": 105, ""special-attack"": 70, ""special-defense"": 120}","Clay Doll Pokémon","Claydol is an enigma that appeared from a clay statue made by
+an ancient civilization dating back 20,000 years. This Pokémon
+shoots beams from both its hands."
+345,"Lileep","[""grass"", ""rock""]",10.00,238.00,"[""storm-drain"", ""suction-cups""]","[""water3""]","{""hp"": 66, ""speed"": 23, ""attack"": 41, ""defense"": 77, ""special-attack"": 61, ""special-defense"": 87}","Sea Lily Pokémon","Lileep is an ancient Pokémon that was regenerated from a
+fossil. It remains permanently anchored to a rock. From its
+immobile perch, this Pokémon intently scans for prey with its
+two eyes."
+346,"Cradily","[""grass"", ""rock""]",15.00,604.00,"[""storm-drain"", ""suction-cups""]","[""water3""]","{""hp"": 86, ""speed"": 43, ""attack"": 81, ""defense"": 97, ""special-attack"": 81, ""special-defense"": 107}","Barnacle Pokémon","Cradily’s body serves as an anchor, preventing it from being
+washed away in rough seas. This Pokémon secretes a strong
+digestive fluid from its tentacles."
+347,"Anorith","[""bug"", ""rock""]",7.00,125.00,"[""swift-swim"", ""battle-armor""]","[""water3""]","{""hp"": 45, ""speed"": 75, ""attack"": 95, ""defense"": 50, ""special-attack"": 40, ""special-defense"": 50}","Old Shrimp Pokémon","Anorith is said to be a type of Pokémon predecessor, with
+eight wings at the sides of its body. This Pokémon swam in the
+primordial sea by undulating these eight wings."
+348,"Armaldo","[""bug"", ""rock""]",15.00,682.00,"[""swift-swim"", ""battle-armor""]","[""water3""]","{""hp"": 75, ""speed"": 45, ""attack"": 125, ""defense"": 100, ""special-attack"": 70, ""special-defense"": 80}","Plate Pokémon","Armaldo is a Pokémon species that became extinct in
+prehistoric times. This Pokémon is said to have walked
+on its hind legs, which would have been more convenient
+for life on land."
+349,"Feebas","[""water""]",6.00,74.00,"[""adaptability"", ""oblivious"", ""swift-swim""]","[""dragon"", ""water1""]","{""hp"": 20, ""speed"": 80, ""attack"": 15, ""defense"": 20, ""special-attack"": 10, ""special-defense"": 55}","Fish Pokémon","Although unattractive and unpopular, this
+Pokémon’s marvelous vitality has made it a
+subject of research."
+350,"Milotic","[""water""]",62.00,1620.00,"[""cute-charm"", ""competitive"", ""marvel-scale""]","[""dragon"", ""water1""]","{""hp"": 95, ""speed"": 81, ""attack"": 60, ""defense"": 79, ""special-attack"": 100, ""special-defense"": 125}","Tender Pokémon","It lives at the bottom of clear lakes. In times of
+war, it shows itself, which soothes people’s
+minds and hearts."
+351,"Castform","[""normal""]",3.00,8.00,"[""forecast""]","[""indeterminate"", ""fairy""]","{""hp"": 70, ""speed"": 70, ""attack"": 70, ""defense"": 70, ""special-attack"": 70, ""special-defense"": 70}","Weather Pokémon","Its form changes on its own, due to its cells’
+sensitive reactions to temperature and humidity."
+352,"Kecleon","[""normal""]",10.00,220.00,"[""protean"", ""color-change""]","[""ground""]","{""hp"": 60, ""speed"": 40, ""attack"": 90, ""defense"": 70, ""special-attack"": 60, ""special-defense"": 120}","Color Swap Pokémon","Kecleon alters its body coloration to blend in with its
+surroundings, allowing it to sneak up on its prey unnoticed.
+Then it lashes out with its long, stretchy tongue to instantly
+ensnare the unsuspecting target."
+353,"Shuppet","[""ghost""]",6.00,23.00,"[""cursed-body"", ""frisk"", ""insomnia""]","[""indeterminate""]","{""hp"": 44, ""speed"": 45, ""attack"": 75, ""defense"": 35, ""special-attack"": 63, ""special-defense"": 33}","Puppet Pokémon","Shuppet grows by feeding on dark emotions, such as
+vengefulness and envy, in the hearts of people. It roams
+through cities in search of grudges that taint people."
+354,"Banette","[""ghost""]",11.00,125.00,"[""cursed-body"", ""frisk"", ""insomnia""]","[""indeterminate""]","{""hp"": 64, ""speed"": 65, ""attack"": 115, ""defense"": 65, ""special-attack"": 83, ""special-defense"": 63}","Marionette Pokémon","A cursed energy permeated the stuffing of a discarded and
+forgotten plush doll, giving it new life as Banette.
+The Pokémon’s energy would escape if it were to ever open
+its mouth."
+355,"Duskull","[""ghost""]",8.00,150.00,"[""frisk"", ""levitate""]","[""indeterminate""]","{""hp"": 20, ""speed"": 25, ""attack"": 40, ""defense"": 90, ""special-attack"": 30, ""special-defense"": 90}","Requiem Pokémon","Duskull wanders lost among the deep darkness of midnight.
+There is an oft-told admonishment given to misbehaving
+children that this Pokémon will spirit away bad children who
+earn scoldings from their mothers."
+356,"Dusclops","[""ghost""]",16.00,306.00,"[""frisk"", ""pressure""]","[""indeterminate""]","{""hp"": 40, ""speed"": 25, ""attack"": 70, ""defense"": 130, ""special-attack"": 60, ""special-defense"": 130}","Beckon Pokémon","Dusclops absorbs anything, however large the object may be.
+This Pokémon hypnotizes its foe by waving its hands in a
+macabre manner and by bringing its single eye to bear.
+The hypnotized foe is made to do Dusclops’s bidding."
+357,"Tropius","[""flying"", ""grass""]",20.00,1000.00,"[""harvest"", ""solar-power"", ""chlorophyll""]","[""plant"", ""monster""]","{""hp"": 99, ""speed"": 51, ""attack"": 68, ""defense"": 83, ""special-attack"": 72, ""special-defense"": 87}","Fruit Pokémon","Children of the southern tropics eat as snacks the fruit that
+grows in bunches around the neck of Tropius. This Pokémon
+flies by flapping the leaves on its back as if they were wings."
+358,"Chimecho","[""psychic""]",6.00,10.00,"[""levitate""]","[""indeterminate""]","{""hp"": 75, ""speed"": 65, ""attack"": 50, ""defense"": 80, ""special-attack"": 95, ""special-defense"": 90}","Wind Chime Pokémon","In high winds, Chimecho cries as it hangs from a tree branch or
+the eaves of a building using a suction cup on its head. This
+Pokémon plucks berries with its long tail and eats them."
+359,"Absol","[""dark""]",12.00,470.00,"[""justified"", ""super-luck"", ""pressure""]","[""ground""]","{""hp"": 65, ""speed"": 75, ""attack"": 130, ""defense"": 60, ""special-attack"": 75, ""special-defense"": 60}","Disaster Pokémon","Although it’s said to bring disaster, in actuality,
+this Pokémon possesses a calm disposition and
+warns people of any crises that loom."
+360,"Wynaut","[""psychic""]",6.00,140.00,"[""telepathy"", ""shadow-tag""]","[""no-eggs""]","{""hp"": 95, ""speed"": 23, ""attack"": 23, ""defense"": 48, ""special-attack"": 23, ""special-defense"": 48}","Bright Pokémon","Wynaut gather on moonlit nights to play by squeezing up
+against each other. By being squeezed, this Pokémon gains
+endurance and is trained to dole out powerful counterattacks."
+361,"Snorunt","[""ice""]",7.00,168.00,"[""moody"", ""ice-body"", ""inner-focus""]","[""mineral"", ""fairy""]","{""hp"": 50, ""speed"": 50, ""attack"": 50, ""defense"": 50, ""special-attack"": 50, ""special-defense"": 50}","Snow Hat Pokémon","It can only survive in cold areas. It bounces
+happily around, even in environments as cold as
+-150 degrees Fahrenheit."
+362,"Glalie","[""ice""]",15.00,2565.00,"[""moody"", ""ice-body"", ""inner-focus""]","[""mineral"", ""fairy""]","{""hp"": 80, ""speed"": 80, ""attack"": 80, ""defense"": 80, ""special-attack"": 80, ""special-defense"": 80}","Face Pokémon","Its prey is instantaneously frozen stiff by the
+cold air it exhales from its huge mouth. While
+they’re in that frozen state, it gobbles them up."
+363,"Spheal","[""water"", ""ice""]",8.00,395.00,"[""oblivious"", ""ice-body"", ""thick-fat""]","[""ground"", ""water1""]","{""hp"": 70, ""speed"": 25, ""attack"": 40, ""defense"": 50, ""special-attack"": 55, ""special-defense"": 50}","Clap Pokémon","Spheal always travels by rolling around on its ball-like body.
+When the season for ice floes arrives, this Pokémon can be
+seen rolling about on ice and crossing the sea."
+364,"Sealeo","[""water"", ""ice""]",11.00,876.00,"[""oblivious"", ""ice-body"", ""thick-fat""]","[""ground"", ""water1""]","{""hp"": 90, ""speed"": 45, ""attack"": 60, ""defense"": 70, ""special-attack"": 75, ""special-defense"": 70}","Ball Roll Pokémon","Sealeo often balances and rolls things on the tip of its
+nose. While the Pokémon is rolling something, it checks
+the object’s aroma and texture to determine whether it likes
+the object or not."
+365,"Walrein","[""water"", ""ice""]",14.00,1506.00,"[""oblivious"", ""ice-body"", ""thick-fat""]","[""ground"", ""water1""]","{""hp"": 110, ""speed"": 65, ""attack"": 80, ""defense"": 90, ""special-attack"": 95, ""special-defense"": 90}","Ice Break Pokémon","Walrein swims all over in frigid seawater while crushing
+icebergs with its grand, imposing tusks. Its thick layer of
+blubber makes enemy attacks bounce off harmlessly."
+366,"Clamperl","[""water""]",4.00,525.00,"[""rattled"", ""shell-armor""]","[""water1""]","{""hp"": 35, ""speed"": 32, ""attack"": 64, ""defense"": 85, ""special-attack"": 74, ""special-defense"": 55}","Bivalve Pokémon","Clamperl grows while being protected by its rock-hard shell.
+When its body becomes too large to fit inside the shell, it is
+sure evidence that this Pokémon is getting close to evolution."
+367,"Huntail","[""water""]",17.00,270.00,"[""water-veil"", ""swift-swim""]","[""water1""]","{""hp"": 55, ""speed"": 52, ""attack"": 104, ""defense"": 105, ""special-attack"": 94, ""special-defense"": 75}","Deep Sea Pokémon","Huntail’s tail is shaped like a fish. It uses the tail to attract
+prey, then swallows the prey whole with its large, gaping
+mouth. This Pokémon swims by wiggling its slender body
+like a snake."
+368,"Gorebyss","[""water""]",18.00,226.00,"[""hydration"", ""swift-swim""]","[""water1""]","{""hp"": 55, ""speed"": 52, ""attack"": 84, ""defense"": 105, ""special-attack"": 114, ""special-defense"": 75}","South Sea Pokémon","Although Gorebyss is the very picture of elegance and beauty
+while swimming, it is also cruel. When it spots prey, this
+Pokémon inserts its thin mouth into the prey’s body and drains
+the prey of its body fluids."
+369,"Relicanth","[""rock"", ""water""]",10.00,234.00,"[""sturdy"", ""rock-head"", ""swift-swim""]","[""water2"", ""water1""]","{""hp"": 100, ""speed"": 55, ""attack"": 90, ""defense"": 130, ""special-attack"": 45, ""special-defense"": 65}","Longevity Pokémon","It was fortuitously discovered during a deep sea
+expedition. Its teeth have atrophied, so it now
+survives on microscopic organisms it sucks up."
+370,"Luvdisc","[""water""]",6.00,87.00,"[""hydration"", ""swift-swim""]","[""water2""]","{""hp"": 43, ""speed"": 97, ""attack"": 30, ""defense"": 55, ""special-attack"": 40, ""special-defense"": 65}","Rendezvous Pokémon","Loving couples have a soft spot for this
+Pokémon, so honeymoon hotels often release
+this Pokémon into their pools."
+371,"Bagon","[""dragon""]",6.00,421.00,"[""sheer-force"", ""rock-head""]","[""dragon""]","{""hp"": 45, ""speed"": 50, ""attack"": 75, ""defense"": 60, ""special-attack"": 40, ""special-defense"": 30}","Rock Head Pokémon","With its steel-hard stone head, it headbutts
+indiscriminately. This is because of the stress
+it feels at being unable to fly."
+372,"Shelgon","[""dragon""]",11.00,1105.00,"[""overcoat"", ""rock-head""]","[""dragon""]","{""hp"": 65, ""speed"": 50, ""attack"": 95, ""defense"": 100, ""special-attack"": 60, ""special-defense"": 50}","Endurance Pokémon","They lurk deep within caves—motionless,
+neither eating nor drinking. Why they don’t die is
+not known."
+373,"Salamence","[""flying"", ""dragon""]",15.00,1026.00,"[""moxie"", ""intimidate""]","[""dragon""]","{""hp"": 95, ""speed"": 100, ""attack"": 135, ""defense"": 80, ""special-attack"": 110, ""special-defense"": 80}","Dragon Pokémon","It flies around on its wings, which have grown in
+at last. In its happiness, it gushes hot flames,
+burning up the fields it passes over."
+374,"Beldum","[""psychic"", ""steel""]",6.00,952.00,"[""light-metal"", ""clear-body""]","[""mineral""]","{""hp"": 40, ""speed"": 30, ""attack"": 55, ""defense"": 80, ""special-attack"": 35, ""special-defense"": 60}","Iron Ball Pokémon","With magnetic traction, it pulls its opponents in
+close. When they’re in range, it slashes them
+with its rear claws."
+375,"Metang","[""psychic"", ""steel""]",12.00,2025.00,"[""light-metal"", ""clear-body""]","[""mineral""]","{""hp"": 60, ""speed"": 50, ""attack"": 75, ""defense"": 100, ""special-attack"": 55, ""special-defense"": 80}","Iron Claw Pokémon","It adores magnetic minerals, so it pursues
+Nosepass at speeds exceeding 60 mph."
+376,"Metagross","[""psychic"", ""steel""]",16.00,5500.00,"[""light-metal"", ""clear-body""]","[""mineral""]","{""hp"": 80, ""speed"": 70, ""attack"": 135, ""defense"": 130, ""special-attack"": 95, ""special-defense"": 90}","Iron Leg Pokémon","A linkage of two Metang, this Pokémon can
+perform any calculation in a flash by utilizing
+parallel processing in its four brains."
+377,"Regirock","[""rock""]",17.00,2300.00,"[""sturdy"", ""clear-body""]","[""no-eggs""]","{""hp"": 80, ""speed"": 50, ""attack"": 100, ""defense"": 200, ""special-attack"": 50, ""special-defense"": 100}","Rock Peak Pokémon","Regirock’s body is composed entirely of rocks. Recently,
+a study made the startling discovery that the rocks were all
+unearthed from different locations."
+378,"Regice","[""ice""]",18.00,1750.00,"[""ice-body"", ""clear-body""]","[""no-eggs""]","{""hp"": 80, ""speed"": 50, ""attack"": 50, ""defense"": 100, ""special-attack"": 100, ""special-defense"": 200}","Iceberg Pokémon","Regice cloaks itself with frigid air of -328 degrees Fahrenheit.
+Things will freeze solid just by going near this Pokémon.
+Its icy body is so cold, it will not melt even if it is immersed
+in magma."
+379,"Registeel","[""steel""]",19.00,2050.00,"[""light-metal"", ""clear-body""]","[""no-eggs""]","{""hp"": 80, ""speed"": 50, ""attack"": 75, ""defense"": 150, ""special-attack"": 75, ""special-defense"": 150}","Iron Pokémon","Registeel was imprisoned by people in ancient times.
+The metal composing its body is thought to be a curious
+substance that is not of this earth."
+380,"Latias","[""psychic"", ""dragon""]",14.00,400.00,"[""levitate""]","[""no-eggs""]","{""hp"": 80, ""speed"": 110, ""attack"": 80, ""defense"": 90, ""special-attack"": 110, ""special-defense"": 130}","Eon Pokémon","Latias is highly intelligent and capable of understanding
+human speech. It is covered with a glass-like down.
+The Pokémon enfolds its body with its down and refracts
+light to alter its appearance."
+381,"Latios","[""psychic"", ""dragon""]",20.00,600.00,"[""levitate""]","[""no-eggs""]","{""hp"": 80, ""speed"": 110, ""attack"": 90, ""defense"": 80, ""special-attack"": 130, ""special-defense"": 110}","Eon Pokémon","Latios will only open its heart to a Trainer with a
+compassionate spirit. This Pokémon can fly faster than a
+jet plane by folding its forelegs to minimize air resistance."
+382,"Kyogre","[""water""]",45.00,3520.00,"[""drizzle""]","[""no-eggs""]","{""hp"": 100, ""speed"": 90, ""attack"": 100, ""defense"": 90, ""special-attack"": 150, ""special-defense"": 140}","Sea Basin Pokémon","Kyogre is said to be the personification of the sea itself.
+Legends tell of its many clashes against Groudon,
+as each sought to gain the power of nature."
+383,"Groudon","[""ground""]",35.00,9500.00,"[""drought""]","[""no-eggs""]","{""hp"": 100, ""speed"": 90, ""attack"": 150, ""defense"": 140, ""special-attack"": 100, ""special-defense"": 90}","Continent Pokémon","Through Primal Reversion and with nature’s full power,
+it will take back its true form. It can cause magma to
+erupt and expand the landmass of the world."
+384,"Rayquaza","[""flying"", ""dragon""]",70.00,2065.00,"[""air-lock""]","[""no-eggs""]","{""hp"": 105, ""speed"": 95, ""attack"": 150, ""defense"": 90, ""special-attack"": 150, ""special-defense"": 90}","Sky High Pokémon","It flies forever through the ozone layer, consuming
+meteoroids for sustenance. The many meteoroids
+in its body provide the energy it needs to Mega Evolve."
+385,"Jirachi","[""psychic"", ""steel""]",3.00,11.00,"[""serene-grace""]","[""no-eggs""]","{""hp"": 100, ""speed"": 100, ""attack"": 100, ""defense"": 100, ""special-attack"": 100, ""special-defense"": 100}","Wish Pokémon","Jirachi will awaken from its sleep of a thousand years if you
+sing to it in a voice of purity. It is said to make true any wish
+that people desire."
+386,"Deoxys","[""psychic""]",17.00,608.00,"[""pressure""]","[""no-eggs""]","{""hp"": 50, ""speed"": 150, ""attack"": 150, ""defense"": 50, ""special-attack"": 150, ""special-defense"": 50}","DNA Pokémon","Deoxys emerged from a virus that came from space. It is highly
+intelligent and wields psychokinetic powers. This Pokémon
+shoots lasers from the crystalline organ on its chest."
+387,"Turtwig","[""grass""]",4.00,102.00,"[""shell-armor"", ""overgrow""]","[""plant"", ""monster""]","{""hp"": 55, ""speed"": 31, ""attack"": 68, ""defense"": 64, ""special-attack"": 45, ""special-defense"": 55}","Tiny Leaf Pokémon","It undertakes photosynthesis with its body, making
+oxygen. The leaf on its head wilts if it is thirsty."
+388,"Grotle","[""grass""]",11.00,970.00,"[""shell-armor"", ""overgrow""]","[""plant"", ""monster""]","{""hp"": 75, ""speed"": 36, ""attack"": 89, ""defense"": 85, ""special-attack"": 55, ""special-defense"": 65}","Grove Pokémon","It knows where pure water wells up. It carries fellow
+Pokémon there on its back."
+389,"Torterra","[""ground"", ""grass""]",22.00,3100.00,"[""shell-armor"", ""overgrow""]","[""plant"", ""monster""]","{""hp"": 95, ""speed"": 56, ""attack"": 109, ""defense"": 105, ""special-attack"": 75, ""special-defense"": 85}","Continent Pokémon","Small Pokémon occasionally gather on its unmoving
+back to begin building their nests."
+390,"Chimchar","[""fire""]",5.00,62.00,"[""iron-fist"", ""blaze""]","[""humanshape"", ""ground""]","{""hp"": 44, ""speed"": 61, ""attack"": 58, ""defense"": 44, ""special-attack"": 58, ""special-defense"": 44}","Chimp Pokémon","The gas made in its belly burns from its rear end.
+The fire burns weakly when it feels sick."
+391,"Monferno","[""fighting"", ""fire""]",9.00,220.00,"[""iron-fist"", ""blaze""]","[""humanshape"", ""ground""]","{""hp"": 64, ""speed"": 81, ""attack"": 78, ""defense"": 52, ""special-attack"": 78, ""special-defense"": 52}","Playful Pokémon","It uses ceilings and walls to launch aerial attacks.
+Its fiery tail is but one weapon."
+392,"Infernape","[""fighting"", ""fire""]",12.00,550.00,"[""iron-fist"", ""blaze""]","[""humanshape"", ""ground""]","{""hp"": 76, ""speed"": 108, ""attack"": 104, ""defense"": 71, ""special-attack"": 104, ""special-defense"": 71}","Flame Pokémon","It tosses its enemies around with agility. It uses all
+its limbs to fight in its own unique style."
+393,"Piplup","[""water""]",4.00,52.00,"[""defiant"", ""torrent""]","[""ground"", ""water1""]","{""hp"": 53, ""speed"": 40, ""attack"": 51, ""defense"": 53, ""special-attack"": 61, ""special-defense"": 56}","Penguin Pokémon","Because it is very proud, it hates accepting food
+from people. Its thick down guards it from cold."
+394,"Prinplup","[""water""]",8.00,230.00,"[""defiant"", ""torrent""]","[""ground"", ""water1""]","{""hp"": 64, ""speed"": 50, ""attack"": 66, ""defense"": 68, ""special-attack"": 81, ""special-defense"": 76}","Penguin Pokémon","It lives a solitary life. Its wings deliver wicked blows
+that can snap even the thickest of trees."
+395,"Empoleon","[""steel"", ""water""]",17.00,845.00,"[""defiant"", ""torrent""]","[""ground"", ""water1""]","{""hp"": 84, ""speed"": 60, ""attack"": 86, ""defense"": 88, ""special-attack"": 111, ""special-defense"": 101}","Emperor Pokémon","The three horns that extend from its beak attest to
+its power. The leader has the biggest horns."
+396,"Starly","[""flying"", ""normal""]",3.00,20.00,"[""reckless"", ""keen-eye""]","[""flying""]","{""hp"": 40, ""speed"": 60, ""attack"": 55, ""defense"": 30, ""special-attack"": 30, ""special-defense"": 30}","Starling Pokémon","They flock around mountains and fields, chasing
+after bug Pokémon. Their singing is noisy
+and annoying."
+397,"Staravia","[""flying"", ""normal""]",6.00,155.00,"[""reckless"", ""intimidate""]","[""flying""]","{""hp"": 55, ""speed"": 80, ""attack"": 75, ""defense"": 50, ""special-attack"": 40, ""special-defense"": 40}","Starling Pokémon","It lives in forests and fields. Squabbles over
+territory occur when flocks collide."
+398,"Staraptor","[""flying"", ""normal""]",12.00,249.00,"[""reckless"", ""intimidate""]","[""flying""]","{""hp"": 85, ""speed"": 100, ""attack"": 120, ""defense"": 70, ""special-attack"": 50, ""special-defense"": 60}","Predator Pokémon","When Staravia evolve into Staraptor, they leave the
+flock to live alone. They have sturdy wings."
+399,"Bidoof","[""normal""]",5.00,200.00,"[""moody"", ""unaware"", ""simple""]","[""ground"", ""water1""]","{""hp"": 59, ""speed"": 31, ""attack"": 45, ""defense"": 40, ""special-attack"": 35, ""special-defense"": 40}","Plump Mouse Pokémon","It constantly gnaws on logs and rocks to whittle
+down its front teeth. It nests alongside water."
+400,"Bibarel","[""water"", ""normal""]",10.00,315.00,"[""moody"", ""unaware"", ""simple""]","[""ground"", ""water1""]","{""hp"": 79, ""speed"": 71, ""attack"": 85, ""defense"": 60, ""special-attack"": 55, ""special-defense"": 60}","Beaver Pokémon","It makes its nest by damming streams with bark and
+mud. It is known as an industrious worker."
+401,"Kricketot","[""bug""]",3.00,22.00,"[""run-away"", ""shed-skin""]","[""bug""]","{""hp"": 37, ""speed"": 25, ""attack"": 25, ""defense"": 41, ""special-attack"": 25, ""special-defense"": 41}","Cricket Pokémon","When its antennae hit each other, it sounds like the
+music of a xylophone."
+402,"Kricketune","[""bug""]",10.00,255.00,"[""technician"", ""swarm""]","[""bug""]","{""hp"": 77, ""speed"": 65, ""attack"": 85, ""defense"": 51, ""special-attack"": 55, ""special-defense"": 51}","Cricket Pokémon","It signals its emotions with its melodies. Scientists
+are studying these melodic patterns."
+403,"Shinx","[""electric""]",5.00,95.00,"[""guts"", ""intimidate"", ""rivalry""]","[""ground""]","{""hp"": 45, ""speed"": 45, ""attack"": 65, ""defense"": 34, ""special-attack"": 40, ""special-defense"": 34}","Flash Pokémon","All of its fur dazzles if danger is sensed. It flees
+while the foe is momentarily blinded."
+404,"Luxio","[""electric""]",9.00,305.00,"[""guts"", ""intimidate"", ""rivalry""]","[""ground""]","{""hp"": 60, ""speed"": 60, ""attack"": 85, ""defense"": 49, ""special-attack"": 60, ""special-defense"": 49}","Spark Pokémon","Strong electricity courses through the tips of its
+sharp claws. A light scratch causes fainting in foes."
+405,"Luxray","[""electric""]",14.00,420.00,"[""guts"", ""intimidate"", ""rivalry""]","[""ground""]","{""hp"": 80, ""speed"": 70, ""attack"": 120, ""defense"": 79, ""special-attack"": 95, ""special-defense"": 79}","Gleam Eyes Pokémon","Luxray’s ability to see through objects comes in
+handy when it’s scouting for danger."
+406,"Budew","[""poison"", ""grass""]",2.00,12.00,"[""leaf-guard"", ""poison-point"", ""natural-cure""]","[""no-eggs""]","{""hp"": 40, ""speed"": 55, ""attack"": 30, ""defense"": 35, ""special-attack"": 50, ""special-defense"": 70}","Bud Pokémon","Over the winter, it closes its bud and endures the
+cold. In spring, the bud opens and releases pollen."
+407,"Roserade","[""poison"", ""grass""]",9.00,145.00,"[""technician"", ""poison-point"", ""natural-cure""]","[""plant"", ""fairy""]","{""hp"": 60, ""speed"": 90, ""attack"": 70, ""defense"": 65, ""special-attack"": 125, ""special-defense"": 105}","Bouquet Pokémon","With the movements of a dancer, it strikes with
+whips that are densely lined with poison thorns."
+408,"Cranidos","[""rock""]",9.00,315.00,"[""sheer-force"", ""mold-breaker""]","[""monster""]","{""hp"": 67, ""speed"": 58, ""attack"": 125, ""defense"": 40, ""special-attack"": 30, ""special-defense"": 30}","Head Butt Pokémon","In rock layers where Cranidos fossils are found,
+the fossilized trunks of trees snapped in two
+are also often found."
+409,"Rampardos","[""rock""]",16.00,1025.00,"[""sheer-force"", ""mold-breaker""]","[""monster""]","{""hp"": 97, ""speed"": 58, ""attack"": 165, ""defense"": 60, ""special-attack"": 65, ""special-defense"": 50}","Head Butt Pokémon","Records exist of a revived fossil that evolved
+into Rampardos. It proceeded to escape and
+then destroy a skyscraper with a headbutt."
+410,"Shieldon","[""steel"", ""rock""]",5.00,570.00,"[""soundproof"", ""sturdy""]","[""monster""]","{""hp"": 30, ""speed"": 30, ""attack"": 42, ""defense"": 118, ""special-attack"": 42, ""special-defense"": 88}","Shield Pokémon","This Pokémon lived in primeval jungles. Few
+enemies would have been willing to square off
+against its heavily armored face, so it’s thought."
+411,"Bastiodon","[""steel"", ""rock""]",13.00,1495.00,"[""soundproof"", ""sturdy""]","[""monster""]","{""hp"": 60, ""speed"": 30, ""attack"": 52, ""defense"": 168, ""special-attack"": 47, ""special-defense"": 138}","Shield Pokémon","It lived in the same environments as Rampardos.
+Their fossils have been found together—
+seemingly from after they’d fought to the finish."
+412,"Burmy","[""bug""]",2.00,34.00,"[""overcoat"", ""shed-skin""]","[""bug""]","{""hp"": 40, ""speed"": 36, ""attack"": 29, ""defense"": 45, ""special-attack"": 29, ""special-defense"": 45}","Bagworm Pokémon","If its cloak is broken in battle, it quickly remakes
+the cloak with materials nearby."
+413,"Wormadam","[""grass"", ""bug""]",5.00,65.00,"[""overcoat"", ""anticipation""]","[""bug""]","{""hp"": 60, ""speed"": 36, ""attack"": 59, ""defense"": 85, ""special-attack"": 79, ""special-defense"": 105}","Bagworm Pokémon","When Burmy evolved, its cloak became a part of
+this Pokémon’s body. The cloak is never shed."
+414,"Mothim","[""flying"", ""bug""]",9.00,233.00,"[""tinted-lens"", ""swarm""]","[""bug""]","{""hp"": 70, ""speed"": 66, ""attack"": 94, ""defense"": 50, ""special-attack"": 94, ""special-defense"": 50}","Moth Pokémon","It flutters around at night and steals honey from
+the Combee hive."
+415,"Combee","[""flying"", ""bug""]",3.00,55.00,"[""hustle"", ""honey-gather""]","[""bug""]","{""hp"": 30, ""speed"": 70, ""attack"": 30, ""defense"": 42, ""special-attack"": 30, ""special-defense"": 42}","Tiny Bee Pokémon","It collects and delivers honey to its colony.
+At night, they cluster to form a beehive and sleep."
+416,"Vespiquen","[""flying"", ""bug""]",12.00,385.00,"[""unnerve"", ""pressure""]","[""bug""]","{""hp"": 70, ""speed"": 40, ""attack"": 80, ""defense"": 102, ""special-attack"": 80, ""special-defense"": 102}","Beehive Pokémon","Its abdomen is a honeycomb for grubs. It raises its
+grubs on honey collected by Combee."
+417,"Pachirisu","[""electric""]",4.00,39.00,"[""volt-absorb"", ""pickup"", ""run-away""]","[""fairy"", ""ground""]","{""hp"": 60, ""speed"": 95, ""attack"": 45, ""defense"": 70, ""special-attack"": 45, ""special-defense"": 90}","EleSquirrel Pokémon","A pair may be seen rubbing their cheek pouches
+together in an effort to share stored electricity."
+418,"Buizel","[""water""]",7.00,295.00,"[""water-veil"", ""swift-swim""]","[""ground"", ""water1""]","{""hp"": 55, ""speed"": 85, ""attack"": 65, ""defense"": 35, ""special-attack"": 60, ""special-defense"": 30}","Sea Weasel Pokémon","It inflates the flotation sac around its neck and
+pokes its head out of the water to see what is
+going on."
+419,"Floatzel","[""water""]",11.00,335.00,"[""water-veil"", ""swift-swim""]","[""ground"", ""water1""]","{""hp"": 85, ""speed"": 115, ""attack"": 105, ""defense"": 55, ""special-attack"": 85, ""special-defense"": 50}","Sea Weasel Pokémon","Its flotation sac developed as a result of pursuing
+aquatic prey. It can double as a rubber raft."
+420,"Cherubi","[""grass""]",4.00,33.00,"[""chlorophyll""]","[""plant"", ""fairy""]","{""hp"": 45, ""speed"": 35, ""attack"": 35, ""defense"": 45, ""special-attack"": 62, ""special-defense"": 53}","Cherry Pokémon","It evolves by sucking the energy out of the small
+ball where it had been storing nutrients."
+421,"Cherrim","[""grass""]",5.00,93.00,"[""flower-gift""]","[""plant"", ""fairy""]","{""hp"": 70, ""speed"": 85, ""attack"": 60, ""defense"": 70, ""special-attack"": 87, ""special-defense"": 78}","Blossom Pokémon","If it senses strong sunlight, it opens its folded
+petals to absorb the sun’s rays with its whole body."
+422,"Shellos","[""water""]",3.00,63.00,"[""sand-force"", ""storm-drain"", ""sticky-hold""]","[""indeterminate"", ""water1""]","{""hp"": 76, ""speed"": 34, ""attack"": 48, ""defense"": 48, ""special-attack"": 57, ""special-defense"": 62}","Sea Slug Pokémon","Purple mucus sticks to the hands of anyone
+who touches it. Take care, as the substance is
+troublesome to wash off. "
+423,"Gastrodon","[""ground"", ""water""]",9.00,299.00,"[""sand-force"", ""storm-drain"", ""sticky-hold""]","[""indeterminate"", ""water1""]","{""hp"": 111, ""speed"": 39, ""attack"": 83, ""defense"": 68, ""special-attack"": 92, ""special-defense"": 82}","Sea Slug Pokémon","Plankton, invisible to the naked eye, is its main
+food source. It comes onto the land periodically,
+but the reason for this is not known."
+424,"Ambipom","[""normal""]",12.00,203.00,"[""skill-link"", ""pickup"", ""technician""]","[""ground""]","{""hp"": 75, ""speed"": 115, ""attack"": 100, ""defense"": 66, ""special-attack"": 60, ""special-defense"": 66}","Long Tail Pokémon","To eat, it deftly shucks nuts with its two tails.
+It rarely uses its arms now."
+425,"Drifloon","[""flying"", ""ghost""]",4.00,12.00,"[""flare-boost"", ""unburden"", ""aftermath""]","[""indeterminate""]","{""hp"": 90, ""speed"": 70, ""attack"": 50, ""defense"": 34, ""special-attack"": 60, ""special-defense"": 44}","Balloon Pokémon","If for some reason its body bursts, its soul spills
+out with a screaming sound."
+426,"Drifblim","[""flying"", ""ghost""]",12.00,150.00,"[""flare-boost"", ""unburden"", ""aftermath""]","[""indeterminate""]","{""hp"": 150, ""speed"": 80, ""attack"": 80, ""defense"": 44, ""special-attack"": 90, ""special-defense"": 54}","Blimp Pokémon","Even while under careful observation, large
+flocks of Drifblim flying at dusk will inexplicably
+disappear from view."
+427,"Buneary","[""normal""]",4.00,55.00,"[""limber"", ""klutz"", ""run-away""]","[""humanshape"", ""ground""]","{""hp"": 55, ""speed"": 85, ""attack"": 66, ""defense"": 44, ""special-attack"": 44, ""special-defense"": 56}","Rabbit Pokémon","When it senses danger, it perks up its ears.
+On cold nights, it sleeps with its head tucked into
+its fur."
+428,"Lopunny","[""normal""]",12.00,333.00,"[""limber"", ""klutz"", ""cute-charm""]","[""humanshape"", ""ground""]","{""hp"": 65, ""speed"": 105, ""attack"": 76, ""defense"": 84, ""special-attack"": 54, ""special-defense"": 96}","Rabbit Pokémon","The ears appear to be delicate. If they are touched
+roughly, it kicks with its graceful legs."
+429,"Mismagius","[""ghost""]",9.00,44.00,"[""levitate""]","[""indeterminate""]","{""hp"": 60, ""speed"": 105, ""attack"": 60, ""defense"": 60, ""special-attack"": 105, ""special-defense"": 105}","Magical Pokémon","Mismagius have been known to cast spells to
+make people fall in love, so some people search
+for this Pokémon as if their life depended on it."
+430,"Honchkrow","[""flying"", ""dark""]",9.00,273.00,"[""moxie"", ""super-luck"", ""insomnia""]","[""flying""]","{""hp"": 100, ""speed"": 71, ""attack"": 125, ""defense"": 52, ""special-attack"": 105, ""special-defense"": 52}","Big Boss Pokémon","If its Murkrow cronies fail to catch food for it,
+or if it feels they have betrayed it, it will hunt
+them down wherever they are and punish them."
+431,"Glameow","[""normal""]",5.00,39.00,"[""keen-eye"", ""own-tempo"", ""limber""]","[""ground""]","{""hp"": 49, ""speed"": 85, ""attack"": 55, ""defense"": 42, ""special-attack"": 42, ""special-defense"": 37}","Catty Pokémon","When it’s happy, Glameow demonstrates beautiful
+movements of its tail, like a dancing ribbon."
+432,"Purugly","[""normal""]",10.00,438.00,"[""defiant"", ""own-tempo"", ""thick-fat""]","[""ground""]","{""hp"": 71, ""speed"": 112, ""attack"": 82, ""defense"": 64, ""special-attack"": 64, ""special-defense"": 59}","Tiger Cat Pokémon","To make itself appear intimidatingly beefy, it tightly
+cinches its waist with its twin tails."
+433,"Chingling","[""psychic""]",2.00,6.00,"[""levitate""]","[""no-eggs""]","{""hp"": 45, ""speed"": 45, ""attack"": 30, ""defense"": 50, ""special-attack"": 65, ""special-defense"": 50}","Bell Pokémon","There is an orb inside its mouth. When it hops,
+the orb bounces all over and makes a
+ringing sound."
+434,"Stunky","[""dark"", ""poison""]",4.00,192.00,"[""keen-eye"", ""aftermath"", ""stench""]","[""ground""]","{""hp"": 63, ""speed"": 74, ""attack"": 63, ""defense"": 47, ""special-attack"": 41, ""special-defense"": 41}","Skunk Pokémon","It protects itself by spraying a noxious fluid from its
+rear. The stench lingers for 24 hours."
+435,"Skuntank","[""dark"", ""poison""]",10.00,380.00,"[""keen-eye"", ""aftermath"", ""stench""]","[""ground""]","{""hp"": 103, ""speed"": 84, ""attack"": 93, ""defense"": 67, ""special-attack"": 71, ""special-defense"": 61}","Skunk Pokémon","It sprays a stinky fluid from its tail. The fluid smells
+worse the longer it is allowed to fester."
+436,"Bronzor","[""psychic"", ""steel""]",5.00,605.00,"[""heavy-metal"", ""heatproof"", ""levitate""]","[""mineral""]","{""hp"": 57, ""speed"": 23, ""attack"": 24, ""defense"": 86, ""special-attack"": 24, ""special-defense"": 86}","Bronze Pokémon","Implements shaped like it were discovered in
+ancient tombs. It is unknown if they are related."
+437,"Bronzong","[""psychic"", ""steel""]",13.00,1870.00,"[""heavy-metal"", ""heatproof"", ""levitate""]","[""mineral""]","{""hp"": 67, ""speed"": 33, ""attack"": 89, ""defense"": 116, ""special-attack"": 79, ""special-defense"": 116}","Bronze Bell Pokémon","Ancient people believed that petitioning Bronzong
+for rain was the way to make crops grow."
+438,"Bonsly","[""rock""]",5.00,150.00,"[""rattled"", ""rock-head"", ""sturdy""]","[""no-eggs""]","{""hp"": 50, ""speed"": 10, ""attack"": 80, ""defense"": 95, ""special-attack"": 10, ""special-defense"": 45}","Bonsai Pokémon","From its eyes, it can expel excess moisture from
+its body. This liquid is similar in composition to
+human sweat."
+439,"Mime Jr.","[""fairy"", ""psychic""]",6.00,130.00,"[""technician"", ""filter"", ""soundproof""]","[""no-eggs""]","{""hp"": 20, ""speed"": 60, ""attack"": 25, ""defense"": 45, ""special-attack"": 70, ""special-defense"": 90}","Mime Pokémon","It habitually mimics foes. Once mimicked, the foe
+cannot take its eyes off this Pokémon."
+440,"Happiny","[""normal""]",6.00,244.00,"[""friend-guard"", ""serene-grace"", ""natural-cure""]","[""no-eggs""]","{""hp"": 100, ""speed"": 30, ""attack"": 5, ""defense"": 5, ""special-attack"": 15, ""special-defense"": 65}","Playhouse Pokémon","It’s too small to lay eggs yet. As a surrogate,
+it searches out round white stones."
+441,"Chatot","[""flying"", ""normal""]",5.00,19.00,"[""big-pecks"", ""tangled-feet"", ""keen-eye""]","[""flying""]","{""hp"": 76, ""speed"": 91, ""attack"": 65, ""defense"": 45, ""special-attack"": 92, ""special-defense"": 42}","Music Note Pokémon","It can learn and speak human words. If they gather,
+they all learn the same saying."
+442,"Spiritomb","[""dark"", ""ghost""]",10.00,1080.00,"[""infiltrator"", ""pressure""]","[""indeterminate""]","{""hp"": 50, ""speed"": 35, ""attack"": 92, ""defense"": 108, ""special-attack"": 92, ""special-defense"": 108}","Forbidden Pokémon","It was bound to a fissure in an odd keystone as
+punishment for misdeeds 500 years ago."
+443,"Gible","[""ground"", ""dragon""]",7.00,205.00,"[""rough-skin"", ""sand-veil""]","[""dragon"", ""monster""]","{""hp"": 58, ""speed"": 42, ""attack"": 70, ""defense"": 45, ""special-attack"": 40, ""special-defense"": 45}","Land Shark Pokémon","It skulks in caves, and when prey or an enemy
+passes by, it leaps out and chomps them. The
+force of its attack sometimes chips its teeth."
+444,"Gabite","[""ground"", ""dragon""]",14.00,560.00,"[""rough-skin"", ""sand-veil""]","[""dragon"", ""monster""]","{""hp"": 68, ""speed"": 82, ""attack"": 90, ""defense"": 65, ""special-attack"": 50, ""special-defense"": 55}","Cave Pokémon","Shiny objects are its passion. It can be found in
+its cave, scarcely moving, its gaze fixed on the
+jewels it’s amassed or Carbink it has caught."
+445,"Garchomp","[""ground"", ""dragon""]",19.00,950.00,"[""rough-skin"", ""sand-veil""]","[""dragon"", ""monster""]","{""hp"": 108, ""speed"": 102, ""attack"": 130, ""defense"": 95, ""special-attack"": 80, ""special-defense"": 85}","Mach Pokémon","The protuberances on its head serve as
+sensors. It can even detect distant prey."
+446,"Munchlax","[""normal""]",6.00,1050.00,"[""gluttony"", ""thick-fat"", ""pickup""]","[""no-eggs""]","{""hp"": 135, ""speed"": 5, ""attack"": 85, ""defense"": 40, ""special-attack"": 40, ""special-defense"": 85}","Big Eater Pokémon","When it finds something that looks like it might
+be edible, it goes right ahead and swallows it
+whole. That’s why it gets fatter day by day."
+447,"Riolu","[""fighting""]",7.00,202.00,"[""prankster"", ""inner-focus"", ""steadfast""]","[""no-eggs""]","{""hp"": 40, ""speed"": 60, ""attack"": 70, ""defense"": 40, ""special-attack"": 35, ""special-defense"": 40}","Emanation Pokémon","It’s tough enough to run right through the night,
+and it’s also a hard worker, but it’s still just
+a youngster."
+448,"Lucario","[""steel"", ""fighting""]",12.00,540.00,"[""justified"", ""inner-focus"", ""steadfast""]","[""humanshape"", ""ground""]","{""hp"": 70, ""speed"": 90, ""attack"": 110, ""defense"": 70, ""special-attack"": 115, ""special-defense"": 70}","Aura Pokémon","They can detect the species of a living being—
+and its emotions—from over half a mile away.
+They control auras and hunt their prey in packs."
+449,"Hippopotas","[""ground""]",8.00,495.00,"[""sand-force"", ""sand-stream""]","[""ground""]","{""hp"": 68, ""speed"": 32, ""attack"": 72, ""defense"": 78, ""special-attack"": 38, ""special-defense"": 42}","Hippo Pokémon","It enshrouds itself with sand to protect itself from
+germs. It does not enjoy getting wet."
+450,"Hippowdon","[""ground""]",20.00,3000.00,"[""sand-force"", ""sand-stream""]","[""ground""]","{""hp"": 108, ""speed"": 47, ""attack"": 112, ""defense"": 118, ""special-attack"": 68, ""special-defense"": 72}","Heavyweight Pokémon","It blasts internally stored sand from ports on its
+body to create a towering twister for attack."
+451,"Skorupi","[""bug"", ""poison""]",8.00,120.00,"[""keen-eye"", ""sniper"", ""battle-armor""]","[""water3"", ""bug""]","{""hp"": 40, ""speed"": 65, ""attack"": 50, ""defense"": 90, ""special-attack"": 30, ""special-defense"": 55}","Scorpion Pokémon","It burrows under the sand to lie in wait for prey.
+Its tail claws can inject its prey with a
+savage poison."
+452,"Drapion","[""dark"", ""poison""]",13.00,615.00,"[""keen-eye"", ""sniper"", ""battle-armor""]","[""water3"", ""bug""]","{""hp"": 70, ""speed"": 95, ""attack"": 90, ""defense"": 110, ""special-attack"": 60, ""special-defense"": 75}","Ogre Scorpion Pokémon","It has the power in its clawed arms to make scrap
+of a car. The tips of its claws release poison."
+453,"Croagunk","[""fighting"", ""poison""]",7.00,230.00,"[""poison-touch"", ""dry-skin"", ""anticipation""]","[""humanshape""]","{""hp"": 48, ""speed"": 50, ""attack"": 61, ""defense"": 40, ""special-attack"": 61, ""special-defense"": 40}","Toxic Mouth Pokémon","Inflating its poison sacs, it fills the area with an odd
+sound and hits flinching opponents with a
+poison jab."
+454,"Toxicroak","[""fighting"", ""poison""]",13.00,444.00,"[""poison-touch"", ""dry-skin"", ""anticipation""]","[""humanshape""]","{""hp"": 83, ""speed"": 85, ""attack"": 106, ""defense"": 65, ""special-attack"": 86, ""special-defense"": 65}","Toxic Mouth Pokémon","Its knuckle claws secrete a toxin so vile that even a
+scratch could prove fatal."
+455,"Carnivine","[""grass""]",14.00,270.00,"[""levitate""]","[""plant""]","{""hp"": 74, ""speed"": 46, ""attack"": 100, ""defense"": 72, ""special-attack"": 90, ""special-defense"": 72}","Bug Catcher Pokémon","It binds itself to trees in marshes. It attracts prey
+with its sweet-smelling drool and gulps them down."
+456,"Finneon","[""water""]",4.00,70.00,"[""water-veil"", ""storm-drain"", ""swift-swim""]","[""water2""]","{""hp"": 49, ""speed"": 66, ""attack"": 49, ""defense"": 56, ""special-attack"": 49, ""special-defense"": 61}","Wing Fish Pokémon","Its double tail fins propel its energetic jumps.
+When it breaks the surface of the sea, Wingull
+swoop down to grab it on the fly."
+457,"Lumineon","[""water""]",12.00,240.00,"[""water-veil"", ""storm-drain"", ""swift-swim""]","[""water2""]","{""hp"": 69, ""speed"": 91, ""attack"": 69, ""defense"": 76, ""special-attack"": 69, ""special-defense"": 86}","Neon Pokémon","This deep-sea Pokémon lives at the bottom of
+the sea. Its fins haul it over the seabed in
+search of its favorite food—Starmie."
+458,"Mantyke","[""flying"", ""water""]",10.00,650.00,"[""water-veil"", ""water-absorb"", ""swift-swim""]","[""no-eggs""]","{""hp"": 45, ""speed"": 50, ""attack"": 20, ""defense"": 50, ""special-attack"": 60, ""special-defense"": 120}","Kite Pokémon","When it swims close to the surface of the ocean,
+people aboard ships are able to observe the pattern
+on its back."
+459,"Snover","[""ice"", ""grass""]",10.00,505.00,"[""soundproof"", ""snow-warning""]","[""plant"", ""monster""]","{""hp"": 60, ""speed"": 40, ""attack"": 62, ""defense"": 50, ""special-attack"": 62, ""special-defense"": 60}","Frost Tree Pokémon","In the spring, it grows berries with the texture of
+frozen treats around its belly."
+460,"Abomasnow","[""ice"", ""grass""]",22.00,1355.00,"[""soundproof"", ""snow-warning""]","[""plant"", ""monster""]","{""hp"": 90, ""speed"": 60, ""attack"": 92, ""defense"": 75, ""special-attack"": 92, ""special-defense"": 85}","Frost Tree Pokémon","It lives a quiet life on mountains that are perpetually
+covered in snow. It hides itself by whipping
+up blizzards."
+461,"Weavile","[""ice"", ""dark""]",11.00,340.00,"[""pickpocket"", ""pressure""]","[""ground""]","{""hp"": 70, ""speed"": 125, ""attack"": 120, ""defense"": 65, ""special-attack"": 45, ""special-defense"": 85}","Sharp Claw Pokémon","They dwell in cold places. This Pokémon’s main
+food source in Alola is Vulpix and Sandshrew,
+which they carefully divide among their group."
+462,"Magnezone","[""steel"", ""electric""]",12.00,1800.00,"[""analytic"", ""sturdy"", ""magnet-pull""]","[""mineral""]","{""hp"": 70, ""speed"": 60, ""attack"": 70, ""defense"": 115, ""special-attack"": 130, ""special-defense"": 90}","Magnet Area Pokémon","As it zooms through the sky, this Pokémon
+seems to be receiving signals of unknown origin,
+while transmitting signals of unknown purpose."
+463,"Lickilicky","[""normal""]",17.00,1400.00,"[""cloud-nine"", ""oblivious"", ""own-tempo""]","[""monster""]","{""hp"": 110, ""speed"": 50, ""attack"": 85, ""defense"": 95, ""special-attack"": 80, ""special-defense"": 95}","Licking Pokémon","Their saliva contains lots of components that can
+dissolve anything. The numbness caused by their
+lick does not dissipate."
+464,"Rhyperior","[""rock"", ""ground""]",24.00,2828.00,"[""reckless"", ""solid-rock"", ""lightning-rod""]","[""ground"", ""monster""]","{""hp"": 115, ""speed"": 40, ""attack"": 140, ""defense"": 130, ""special-attack"": 55, ""special-defense"": 55}","Drill Pokémon","It puts rocks in holes in its palms and uses its
+muscles to shoot them. Geodude are shot at
+rare times."
+465,"Tangrowth","[""grass""]",20.00,1286.00,"[""regenerator"", ""leaf-guard"", ""chlorophyll""]","[""plant""]","{""hp"": 100, ""speed"": 50, ""attack"": 100, ""defense"": 125, ""special-attack"": 110, ""special-defense"": 50}","Vine Pokémon","Its vines grow so profusely that, in the warm
+season, you can’t even see its eyes."
+466,"Electivire","[""electric""]",18.00,1386.00,"[""vital-spirit"", ""motor-drive""]","[""humanshape""]","{""hp"": 75, ""speed"": 95, ""attack"": 123, ""defense"": 67, ""special-attack"": 95, ""special-defense"": 85}","Thunderbolt Pokémon","When it gets excited, it thumps its chest. With
+every thud, thunder roars and electric sparks
+shower all around."
+467,"Magmortar","[""fire""]",16.00,680.00,"[""vital-spirit"", ""flame-body""]","[""humanshape""]","{""hp"": 75, ""speed"": 83, ""attack"": 95, ""defense"": 67, ""special-attack"": 125, ""special-defense"": 95}","Blast Pokémon","From its arm, it launches fireballs hotter than
+3,500 degrees Fahrenheit. Its arm starts to
+melt when it fires a whole barrage."
+468,"Togekiss","[""flying"", ""fairy""]",15.00,380.00,"[""super-luck"", ""serene-grace"", ""hustle""]","[""fairy"", ""flying""]","{""hp"": 85, ""speed"": 80, ""attack"": 50, ""defense"": 95, ""special-attack"": 120, ""special-defense"": 115}","Jubilee Pokémon","It shares many blessings with people who respect
+one another’s rights and avoid needless strife."
+469,"Yanmega","[""flying"", ""bug""]",19.00,515.00,"[""frisk"", ""tinted-lens"", ""speed-boost""]","[""bug""]","{""hp"": 86, ""speed"": 95, ""attack"": 76, ""defense"": 86, ""special-attack"": 116, ""special-defense"": 56}","Ogre Darner Pokémon","This six-legged Pokémon is easily capable of
+transporting an adult in flight. The wings on its tail
+help it stay balanced."
+470,"Leafeon","[""grass""]",10.00,255.00,"[""chlorophyll"", ""leaf-guard""]","[""ground""]","{""hp"": 65, ""speed"": 95, ""attack"": 110, ""defense"": 130, ""special-attack"": 60, ""special-defense"": 65}","Verdant Pokémon","The younger they are, the more they smell like
+fresh grass. With age, their fragrance takes on
+the odor of fallen leaves."
+471,"Glaceon","[""ice""]",8.00,259.00,"[""ice-body"", ""snow-cloak""]","[""ground""]","{""hp"": 65, ""speed"": 65, ""attack"": 60, ""defense"": 110, ""special-attack"": 130, ""special-defense"": 95}","Fresh Snow Pokémon","It freezes its fur into icicles, spiky and sharp,
+and tackles its prey."
+472,"Gliscor","[""flying"", ""ground""]",20.00,425.00,"[""poison-heal"", ""sand-veil"", ""hyper-cutter""]","[""bug""]","{""hp"": 75, ""speed"": 95, ""attack"": 95, ""defense"": 125, ""special-attack"": 45, ""special-defense"": 75}","Fang Scorpion Pokémon","Its flight is soundless. It uses its lengthy tail to
+carry off its prey... Then its elongated fangs do
+the rest."
+473,"Mamoswine","[""ground"", ""ice""]",25.00,2910.00,"[""thick-fat"", ""snow-cloak"", ""oblivious""]","[""ground""]","{""hp"": 110, ""speed"": 80, ""attack"": 130, ""defense"": 80, ""special-attack"": 70, ""special-defense"": 60}","Twin Tusk Pokémon","Its impressive tusks are made of ice. The population
+thinned when it turned warm after the ice age."
+474,"Porygon-Z","[""normal""]",9.00,340.00,"[""analytic"", ""download"", ""adaptability""]","[""mineral""]","{""hp"": 85, ""speed"": 90, ""attack"": 80, ""defense"": 70, ""special-attack"": 135, ""special-defense"": 75}","Virtual Pokémon","Its program was modified to facilitate
+extra-dimensional activities, but that led to
+noticeably strange behavior."
+475,"Gallade","[""fighting"", ""psychic""]",16.00,520.00,"[""justified"", ""steadfast""]","[""indeterminate""]","{""hp"": 68, ""speed"": 80, ""attack"": 125, ""defense"": 65, ""special-attack"": 65, ""special-defense"": 115}","Blade Pokémon","A master of courtesy and swordsmanship, it fights
+using extending swords on its elbows."
+476,"Probopass","[""steel"", ""rock""]",14.00,3400.00,"[""sand-force"", ""magnet-pull"", ""sturdy""]","[""mineral""]","{""hp"": 60, ""speed"": 40, ""attack"": 55, ""defense"": 145, ""special-attack"": 75, ""special-defense"": 150}","Compass Pokémon","The main body controls three mobile units called
+Mini-Noses, which it maneuvers to catch prey."
+477,"Dusknoir","[""ghost""]",22.00,1066.00,"[""frisk"", ""pressure""]","[""indeterminate""]","{""hp"": 45, ""speed"": 45, ""attack"": 100, ""defense"": 135, ""special-attack"": 65, ""special-defense"": 135}","Gripper Pokémon","The antenna on its head captures radio waves from
+the world of spirits that command it to take
+people there."
+478,"Froslass","[""ghost"", ""ice""]",13.00,266.00,"[""cursed-body"", ""snow-cloak""]","[""mineral"", ""fairy""]","{""hp"": 70, ""speed"": 110, ""attack"": 80, ""defense"": 70, ""special-attack"": 80, ""special-defense"": 70}","Snow Land Pokémon","The soul of a woman lost on a snowy mountain
+possessed an icicle, becoming this Pokémon.
+The food it most relishes is the souls of men."
+479,"Rotom","[""ghost"", ""electric""]",3.00,3.00,"[""levitate""]","[""indeterminate""]","{""hp"": 50, ""speed"": 91, ""attack"": 50, ""defense"": 77, ""special-attack"": 95, ""special-defense"": 77}","Plasma Pokémon","Its body is composed of plasma. It is known to
+infiltrate electronic devices and wreak havoc."
+480,"Uxie","[""psychic""]",3.00,3.00,"[""levitate""]","[""no-eggs""]","{""hp"": 75, ""speed"": 95, ""attack"": 75, ""defense"": 130, ""special-attack"": 75, ""special-defense"": 130}","Knowledge Pokémon","It is said that its emergence gave humans the
+intelligence to improve their quality of life."
+481,"Mesprit","[""psychic""]",3.00,3.00,"[""levitate""]","[""no-eggs""]","{""hp"": 80, ""speed"": 80, ""attack"": 105, ""defense"": 105, ""special-attack"": 105, ""special-defense"": 105}","Emotion Pokémon","It sleeps at the bottom of a lake. Its spirit is said to
+leave its body to fly on the lake’s surface."
+482,"Azelf","[""psychic""]",3.00,3.00,"[""levitate""]","[""no-eggs""]","{""hp"": 75, ""speed"": 115, ""attack"": 125, ""defense"": 70, ""special-attack"": 125, ""special-defense"": 70}","Willpower Pokémon","It is thought that Uxie, Mesprit, and Azelf all came
+from the same egg."
+483,"Dialga","[""dragon"", ""steel""]",54.00,6830.00,"[""telepathy"", ""pressure""]","[""no-eggs""]","{""hp"": 100, ""speed"": 90, ""attack"": 120, ""defense"": 120, ""special-attack"": 150, ""special-defense"": 100}","Temporal Pokémon","It has the power to control time. It appears in
+Sinnoh-region myths as an ancient deity."
+484,"Palkia","[""dragon"", ""water""]",42.00,3360.00,"[""telepathy"", ""pressure""]","[""no-eggs""]","{""hp"": 90, ""speed"": 100, ""attack"": 120, ""defense"": 100, ""special-attack"": 150, ""special-defense"": 120}","Spatial Pokémon","It has the ability to distort space. It is described as
+a deity in Sinnoh-region mythology."
+485,"Heatran","[""steel"", ""fire""]",17.00,4300.00,"[""flame-body"", ""flash-fire""]","[""no-eggs""]","{""hp"": 91, ""speed"": 77, ""attack"": 90, ""defense"": 106, ""special-attack"": 130, ""special-defense"": 106}","Lava Dome Pokémon","Boiling blood, like magma, circulates through its
+body. It makes its dwelling place in volcanic caves."
+486,"Regigigas","[""normal""]",37.00,4200.00,"[""slow-start""]","[""no-eggs""]","{""hp"": 110, ""speed"": 100, ""attack"": 160, ""defense"": 110, ""special-attack"": 80, ""special-defense"": 110}","Colossal Pokémon","There is an enduring legend that states this
+Pokémon towed continents with ropes."
+487,"Giratina","[""dragon"", ""ghost""]",45.00,7500.00,"[""telepathy"", ""pressure""]","[""no-eggs""]","{""hp"": 150, ""speed"": 90, ""attack"": 100, ""defense"": 120, ""special-attack"": 100, ""special-defense"": 120}","Renegade Pokémon","It was banished for its violence. It silently gazed
+upon the old world from the Distortion World."
+488,"Cresselia","[""psychic""]",15.00,856.00,"[""levitate""]","[""no-eggs""]","{""hp"": 120, ""speed"": 85, ""attack"": 70, ""defense"": 120, ""special-attack"": 75, ""special-defense"": 130}","Lunar Pokémon","Those who sleep holding Cresselia’s feather are
+assured of joyful dreams. It is said to represent
+the crescent moon."
+489,"Phione","[""water""]",4.00,31.00,"[""hydration""]","[""fairy"", ""water1""]","{""hp"": 80, ""speed"": 80, ""attack"": 80, ""defense"": 80, ""special-attack"": 80, ""special-defense"": 80}","Sea Drifter Pokémon","It drifts in warm seas. It always returns to where it
+was born, no matter how far it may have drifted."
+490,"Manaphy","[""water""]",3.00,14.00,"[""hydration""]","[""fairy"", ""water1""]","{""hp"": 100, ""speed"": 100, ""attack"": 100, ""defense"": 100, ""special-attack"": 100, ""special-defense"": 100}","Seafaring Pokémon","It starts its life with a wondrous power that permits
+it to bond with any kind of Pokémon."
+491,"Darkrai","[""dark""]",15.00,505.00,"[""bad-dreams""]","[""no-eggs""]","{""hp"": 70, ""speed"": 125, ""attack"": 90, ""defense"": 90, ""special-attack"": 135, ""special-defense"": 90}","Pitch-Black Pokémon","It can lull people to sleep and make them dream.
+It is active during nights of the new moon."
+492,"Shaymin","[""grass""]",2.00,21.00,"[""natural-cure""]","[""no-eggs""]","{""hp"": 100, ""speed"": 100, ""attack"": 100, ""defense"": 100, ""special-attack"": 100, ""special-defense"": 100}","Gratitude Pokémon","The blooming of Gracidea flowers confers the
+power of flight upon it. Feelings of gratitude are
+the message it delivers."
+493,"Arceus","[""normal""]",32.00,3200.00,"[""multitype""]","[""no-eggs""]","{""hp"": 120, ""speed"": 120, ""attack"": 120, ""defense"": 120, ""special-attack"": 120, ""special-defense"": 120}","Alpha Pokémon","It is told in mythology that this Pokémon was born
+before the universe even existed."
+494,"Victini","[""fire"", ""psychic""]",4.00,40.00,"[""victory-star""]","[""no-eggs""]","{""hp"": 100, ""speed"": 100, ""attack"": 100, ""defense"": 100, ""special-attack"": 100, ""special-defense"": 100}","Victory Pokémon","When it shares the infinite energy it creates,
+that being’s entire body will be overflowing
+with power."
+495,"Snivy","[""grass""]",6.00,81.00,"[""contrary"", ""overgrow""]","[""plant"", ""ground""]","{""hp"": 45, ""speed"": 63, ""attack"": 45, ""defense"": 55, ""special-attack"": 45, ""special-defense"": 55}","Grass Snake Pokémon","They photosynthesize by bathing their tails in
+sunlight. When they are not feeling well, their
+tails droop."
+496,"Servine","[""grass""]",8.00,160.00,"[""contrary"", ""overgrow""]","[""plant"", ""ground""]","{""hp"": 60, ""speed"": 83, ""attack"": 60, ""defense"": 75, ""special-attack"": 60, ""special-defense"": 75}","Grass Snake Pokémon","When it gets dirty, its leaves can’t be used in
+photosynthesis, so it always keeps itself clean."
+497,"Serperior","[""grass""]",33.00,630.00,"[""contrary"", ""overgrow""]","[""plant"", ""ground""]","{""hp"": 75, ""speed"": 113, ""attack"": 75, ""defense"": 95, ""special-attack"": 75, ""special-defense"": 95}","Regal Pokémon","It can stop its opponents’ movements with just a
+glare. It takes in solar energy and boosts
+it internally."
+498,"Tepig","[""fire""]",5.00,99.00,"[""thick-fat"", ""blaze""]","[""ground""]","{""hp"": 65, ""speed"": 45, ""attack"": 63, ""defense"": 45, ""special-attack"": 45, ""special-defense"": 45}","Fire Pig Pokémon","It loves to eat roasted berries, but sometimes it
+gets too excited and burns them to a crisp."
+499,"Pignite","[""fighting"", ""fire""]",10.00,555.00,"[""thick-fat"", ""blaze""]","[""ground""]","{""hp"": 90, ""speed"": 55, ""attack"": 93, ""defense"": 55, ""special-attack"": 70, ""special-defense"": 55}","Fire Pig Pokémon","When its internal fire flares up, its movements grow
+sharper and faster. When in trouble, it emits smoke."
+500,"Emboar","[""fighting"", ""fire""]",16.00,1500.00,"[""reckless"", ""blaze""]","[""ground""]","{""hp"": 110, ""speed"": 65, ""attack"": 123, ""defense"": 65, ""special-attack"": 100, ""special-defense"": 65}","Mega Fire Pig Pokémon","It has mastered fast and powerful fighting moves.
+It grows a beard of fire."
+501,"Oshawott","[""water""]",5.00,59.00,"[""shell-armor"", ""torrent""]","[""ground""]","{""hp"": 55, ""speed"": 45, ""attack"": 55, ""defense"": 45, ""special-attack"": 63, ""special-defense"": 45}","Sea Otter Pokémon","It fights using the scalchop on its stomach.
+In response to an attack, it retaliates immediately
+by slashing."
+502,"Dewott","[""water""]",8.00,245.00,"[""shell-armor"", ""torrent""]","[""ground""]","{""hp"": 75, ""speed"": 60, ""attack"": 75, ""defense"": 60, ""special-attack"": 83, ""special-defense"": 60}","Discipline Pokémon","As a result of strict training, each Dewott learns
+different forms for using the scalchops."
+503,"Samurott","[""water""]",15.00,946.00,"[""shell-armor"", ""torrent""]","[""ground""]","{""hp"": 95, ""speed"": 70, ""attack"": 100, ""defense"": 85, ""special-attack"": 108, ""special-defense"": 70}","Formidable Pokémon","One swing of the sword incorporated in its armor
+can fell an opponent. A simple glare from one of
+them quiets everybody."
+504,"Patrat","[""normal""]",5.00,116.00,"[""analytic"", ""keen-eye"", ""run-away""]","[""ground""]","{""hp"": 45, ""speed"": 42, ""attack"": 55, ""defense"": 39, ""special-attack"": 35, ""special-defense"": 39}","Scout Pokémon","Extremely cautious, one of them will always be on
+the lookout, but it won’t notice a foe coming
+from behind."
+505,"Watchog","[""normal""]",11.00,270.00,"[""analytic"", ""keen-eye"", ""illuminate""]","[""ground""]","{""hp"": 60, ""speed"": 77, ""attack"": 85, ""defense"": 69, ""special-attack"": 60, ""special-defense"": 69}","Lookout Pokémon","When they see an enemy, their tails stand high,
+and they spit the seeds of berries stored in their
+cheek pouches."
+506,"Lillipup","[""normal""]",4.00,41.00,"[""run-away"", ""pickup"", ""vital-spirit""]","[""ground""]","{""hp"": 45, ""speed"": 55, ""attack"": 60, ""defense"": 45, ""special-attack"": 25, ""special-defense"": 45}","Puppy Pokémon","The long fur surrounding its face functions as
+radar, enabling it to probe the condition of its
+battle opponents."
+507,"Herdier","[""normal""]",9.00,147.00,"[""scrappy"", ""sand-rush"", ""intimidate""]","[""ground""]","{""hp"": 65, ""speed"": 60, ""attack"": 80, ""defense"": 65, ""special-attack"": 35, ""special-defense"": 65}","Loyal Dog Pokémon","This Pokémon obeys its master’s orders
+faithfully. However, it refuses to listen to
+anything said by a person it doesn’t respect."
+508,"Stoutland","[""normal""]",12.00,610.00,"[""scrappy"", ""sand-rush"", ""intimidate""]","[""ground""]","{""hp"": 85, ""speed"": 80, ""attack"": 110, ""defense"": 90, ""special-attack"": 45, ""special-defense"": 90}","Big-Hearted Pokémon","With this wise Pokémon, there could be no
+concern that it would ever attack people. Some
+parents even trust it to babysit."
+509,"Purrloin","[""dark""]",4.00,101.00,"[""prankster"", ""unburden"", ""limber""]","[""ground""]","{""hp"": 41, ""speed"": 66, ""attack"": 50, ""defense"": 37, ""special-attack"": 50, ""special-defense"": 37}","Devious Pokémon","They steal from people for fun, but their victims
+can’t help but forgive them. Their deceptively cute
+act is perfect."
+510,"Liepard","[""dark""]",11.00,375.00,"[""prankster"", ""unburden"", ""limber""]","[""ground""]","{""hp"": 64, ""speed"": 106, ""attack"": 88, ""defense"": 50, ""special-attack"": 88, ""special-defense"": 50}","Cruel Pokémon","Stealthily, it sneaks up on its target, striking from
+behind before its victim has a chance to react."
+511,"Pansage","[""grass""]",6.00,105.00,"[""overgrow"", ""gluttony""]","[""ground""]","{""hp"": 50, ""speed"": 64, ""attack"": 53, ""defense"": 48, ""special-attack"": 53, ""special-defense"": 48}","Grass Monkey Pokémon","It’s good at finding berries and gathers them from
+all over. It’s kind enough to share them
+with friends."
+512,"Simisage","[""grass""]",11.00,305.00,"[""overgrow"", ""gluttony""]","[""ground""]","{""hp"": 75, ""speed"": 101, ""attack"": 98, ""defense"": 63, ""special-attack"": 98, ""special-defense"": 63}","Thorn Monkey Pokémon","Ill tempered, it fights by swinging its barbed tail
+around wildly. The leaf growing on its head is
+very bitter."
+513,"Pansear","[""fire""]",6.00,110.00,"[""blaze"", ""gluttony""]","[""ground""]","{""hp"": 50, ""speed"": 64, ""attack"": 53, ""defense"": 48, ""special-attack"": 53, ""special-defense"": 48}","High Temp Pokémon","This Pokémon lives in caves in volcanoes.
+The fire within the tuft on its head can reach
+600 degrees Fahrenheit."
+514,"Simisear","[""fire""]",10.00,280.00,"[""blaze"", ""gluttony""]","[""ground""]","{""hp"": 75, ""speed"": 101, ""attack"": 98, ""defense"": 63, ""special-attack"": 98, ""special-defense"": 63}","Ember Pokémon","When it gets excited, embers rise from its head
+and tail and it gets hot. For some reason, it
+loves sweets."
+515,"Panpour","[""water""]",6.00,135.00,"[""torrent"", ""gluttony""]","[""ground""]","{""hp"": 50, ""speed"": 64, ""attack"": 53, ""defense"": 48, ""special-attack"": 53, ""special-defense"": 48}","Spray Pokémon","The water stored inside the tuft on its head is full of
+nutrients. Plants that receive its water grow large."
+516,"Simipour","[""water""]",10.00,290.00,"[""torrent"", ""gluttony""]","[""ground""]","{""hp"": 75, ""speed"": 101, ""attack"": 98, ""defense"": 63, ""special-attack"": 98, ""special-defense"": 63}","Geyser Pokémon","It prefers places with clean water. When its tuft runs
+low, it replenishes it by siphoning up water with
+its tail."
+517,"Munna","[""psychic""]",6.00,233.00,"[""telepathy"", ""synchronize"", ""forewarn""]","[""ground""]","{""hp"": 76, ""speed"": 24, ""attack"": 25, ""defense"": 45, ""special-attack"": 67, ""special-defense"": 55}","Dream Eater Pokémon","It eats the dreams of people and Pokémon. When it
+eats a pleasant dream, it expels pink-colored mist."
+518,"Musharna","[""psychic""]",11.00,605.00,"[""telepathy"", ""synchronize"", ""forewarn""]","[""ground""]","{""hp"": 116, ""speed"": 29, ""attack"": 55, ""defense"": 85, ""special-attack"": 107, ""special-defense"": 95}","Drowsing Pokémon","The dream mist coming from its forehead changes
+into many different colors depending on the dream
+that was eaten."
+519,"Pidove","[""flying"", ""normal""]",3.00,21.00,"[""rivalry"", ""super-luck"", ""big-pecks""]","[""flying""]","{""hp"": 50, ""speed"": 43, ""attack"": 55, ""defense"": 50, ""special-attack"": 36, ""special-defense"": 30}","Tiny Pigeon Pokémon","These Pokémon live in cities. They are accustomed
+to people. Flocks often gather in parks and plazas."
+520,"Tranquill","[""flying"", ""normal""]",6.00,150.00,"[""rivalry"", ""super-luck"", ""big-pecks""]","[""flying""]","{""hp"": 62, ""speed"": 65, ""attack"": 77, ""defense"": 62, ""special-attack"": 50, ""special-defense"": 42}","Wild Pigeon Pokémon","No matter where in the world it goes, it knows
+where its nest is, so it never gets separated from
+its Trainer."
+521,"Unfezant","[""flying"", ""normal""]",12.00,290.00,"[""rivalry"", ""super-luck"", ""big-pecks""]","[""flying""]","{""hp"": 80, ""speed"": 93, ""attack"": 115, ""defense"": 80, ""special-attack"": 65, ""special-defense"": 55}","Proud Pokémon","Males have plumage on their heads. They will never
+let themselves feel close to anyone other than
+their Trainers."
+522,"Blitzle","[""electric""]",8.00,298.00,"[""sap-sipper"", ""motor-drive"", ""lightning-rod""]","[""ground""]","{""hp"": 45, ""speed"": 76, ""attack"": 60, ""defense"": 32, ""special-attack"": 50, ""special-defense"": 32}","Electrified Pokémon","Its mane shines when it discharges electricity.
+They use the frequency and rhythm of these flashes
+to communicate."
+523,"Zebstrika","[""electric""]",16.00,795.00,"[""sap-sipper"", ""motor-drive"", ""lightning-rod""]","[""ground""]","{""hp"": 75, ""speed"": 116, ""attack"": 100, ""defense"": 63, ""special-attack"": 80, ""special-defense"": 63}","Thunderbolt Pokémon","They have lightning-like movements.
+When Zebstrika run at full speed, the sound of
+thunder reverberates."
+524,"Roggenrola","[""rock""]",4.00,180.00,"[""sand-force"", ""weak-armor"", ""sturdy""]","[""mineral""]","{""hp"": 55, ""speed"": 15, ""attack"": 75, ""defense"": 85, ""special-attack"": 25, ""special-defense"": 25}","Mantle Pokémon","The hexagonal cavity is its ear. It walks in the
+direction of sounds it hears, but if the sounds
+cease, it panics and topples over."
+525,"Boldore","[""rock""]",9.00,1020.00,"[""sand-force"", ""weak-armor"", ""sturdy""]","[""mineral""]","{""hp"": 70, ""speed"": 20, ""attack"": 105, ""defense"": 105, ""special-attack"": 50, ""special-defense"": 40}","Ore Pokémon","It explores caves in search of underground
+water. It’s not comfortable around water, so
+this Pokémon takes great care in lapping it up."
+526,"Gigalith","[""rock""]",17.00,2600.00,"[""sand-force"", ""sand-stream"", ""sturdy""]","[""mineral""]","{""hp"": 85, ""speed"": 25, ""attack"": 135, ""defense"": 130, ""special-attack"": 60, ""special-defense"": 80}","Compressed Pokémon","Known for its hefty horsepower, this Pokémon
+is a popular partner for construction workers."
+527,"Woobat","[""flying"", ""psychic""]",4.00,21.00,"[""simple"", ""klutz"", ""unaware""]","[""ground"", ""flying""]","{""hp"": 65, ""speed"": 72, ""attack"": 45, ""defense"": 43, ""special-attack"": 55, ""special-defense"": 43}","Bat Pokémon","The heart-shaped mark left on a body after a
+Woobat has been attached to it is said to bring
+good fortune."
+528,"Swoobat","[""flying"", ""psychic""]",9.00,105.00,"[""simple"", ""klutz"", ""unaware""]","[""ground"", ""flying""]","{""hp"": 67, ""speed"": 114, ""attack"": 57, ""defense"": 55, ""special-attack"": 77, ""special-defense"": 55}","Courting Pokémon","Anyone who comes into contact with the ultrasonic
+waves emitted by a courting male experiences a
+positive mood shift."
+529,"Drilbur","[""ground""]",3.00,85.00,"[""mold-breaker"", ""sand-force"", ""sand-rush""]","[""ground""]","{""hp"": 60, ""speed"": 68, ""attack"": 85, ""defense"": 40, ""special-attack"": 30, ""special-defense"": 45}","Mole Pokémon","By spinning its body, it can dig straight through the
+ground at a speed of 30 mph."
+530,"Excadrill","[""steel"", ""ground""]",7.00,404.00,"[""mold-breaker"", ""sand-force"", ""sand-rush""]","[""ground""]","{""hp"": 110, ""speed"": 88, ""attack"": 135, ""defense"": 60, ""special-attack"": 50, ""special-defense"": 65}","Subterrene Pokémon","More than 300 feet below the surface, they build
+mazelike nests. Their activity can be destructive to
+subway tunnels."
+531,"Audino","[""normal""]",11.00,310.00,"[""klutz"", ""regenerator"", ""healer""]","[""fairy""]","{""hp"": 103, ""speed"": 50, ""attack"": 60, ""defense"": 86, ""special-attack"": 60, ""special-defense"": 86}","Hearing Pokémon","It touches others with the feelers on its ears, using
+the sound of their heartbeats to tell how they
+are feeling."
+532,"Timburr","[""fighting""]",6.00,125.00,"[""iron-fist"", ""sheer-force"", ""guts""]","[""humanshape""]","{""hp"": 75, ""speed"": 35, ""attack"": 80, ""defense"": 55, ""special-attack"": 25, ""special-defense"": 35}","Muscular Pokémon","Always carrying squared logs, they help out with
+construction. As they grow, they carry bigger logs."
+533,"Gurdurr","[""fighting""]",12.00,400.00,"[""iron-fist"", ""sheer-force"", ""guts""]","[""humanshape""]","{""hp"": 85, ""speed"": 40, ""attack"": 105, ""defense"": 85, ""special-attack"": 40, ""special-defense"": 50}","Muscular Pokémon","This Pokémon is so muscular and strongly built that
+even a group of wrestlers could not make it budge
+an inch."
+534,"Conkeldurr","[""fighting""]",14.00,870.00,"[""iron-fist"", ""sheer-force"", ""guts""]","[""humanshape""]","{""hp"": 105, ""speed"": 45, ""attack"": 140, ""defense"": 95, ""special-attack"": 55, ""special-defense"": 65}","Muscular Pokémon","Rather than rely on force, they master moves that
+utilize the centrifugal force of spinning concrete."
+535,"Tympole","[""water""]",5.00,45.00,"[""water-absorb"", ""hydration"", ""swift-swim""]","[""water1""]","{""hp"": 50, ""speed"": 64, ""attack"": 50, ""defense"": 40, ""special-attack"": 50, ""special-defense"": 40}","Tadpole Pokémon","By vibrating its cheeks, it emits sound waves
+imperceptible to humans. It uses the rhythm of
+these sounds to talk."
+536,"Palpitoad","[""ground"", ""water""]",8.00,170.00,"[""water-absorb"", ""hydration"", ""swift-swim""]","[""water1""]","{""hp"": 75, ""speed"": 69, ""attack"": 65, ""defense"": 55, ""special-attack"": 65, ""special-defense"": 55}","Vibration Pokémon","It lives in the water and on land. It uses its long,
+sticky tongue to immobilize its opponents."
+537,"Seismitoad","[""ground"", ""water""]",15.00,620.00,"[""water-absorb"", ""poison-touch"", ""swift-swim""]","[""water1""]","{""hp"": 105, ""speed"": 74, ""attack"": 95, ""defense"": 75, ""special-attack"": 85, ""special-defense"": 75}","Vibration Pokémon","They shoot paralyzing liquid from their head bumps.
+They use vibration to hurt their opponents."
+538,"Throh","[""fighting""]",13.00,555.00,"[""mold-breaker"", ""inner-focus"", ""guts""]","[""humanshape""]","{""hp"": 120, ""speed"": 45, ""attack"": 100, ""defense"": 85, ""special-attack"": 30, ""special-defense"": 85}","Judo Pokémon","When it encounters a foe bigger than itself, it wants
+to throw it. It changes belts as it gets stronger."
+539,"Sawk","[""fighting""]",14.00,510.00,"[""mold-breaker"", ""inner-focus"", ""sturdy""]","[""humanshape""]","{""hp"": 75, ""speed"": 85, ""attack"": 125, ""defense"": 75, ""special-attack"": 30, ""special-defense"": 75}","Karate Pokémon","Tying their belts gets them pumped and makes their
+punches more destructive. Disturbing their training
+angers them."
+540,"Sewaddle","[""grass"", ""bug""]",3.00,25.00,"[""overcoat"", ""chlorophyll"", ""swarm""]","[""bug""]","{""hp"": 45, ""speed"": 42, ""attack"": 53, ""defense"": 70, ""special-attack"": 40, ""special-defense"": 60}","Sewing Pokémon","Since this Pokémon makes its own clothes out of
+leaves, it is a popular mascot for fashion designers."
+541,"Swadloon","[""grass"", ""bug""]",5.00,73.00,"[""overcoat"", ""chlorophyll"", ""leaf-guard""]","[""bug""]","{""hp"": 55, ""speed"": 42, ""attack"": 63, ""defense"": 90, ""special-attack"": 50, ""special-defense"": 80}","Leaf-Wrapped Pokémon","It protects itself from the cold by wrapping up in
+leaves. It stays on the move, eating leaves
+in forests."
+542,"Leavanny","[""grass"", ""bug""]",12.00,205.00,"[""overcoat"", ""chlorophyll"", ""swarm""]","[""bug""]","{""hp"": 75, ""speed"": 92, ""attack"": 103, ""defense"": 80, ""special-attack"": 70, ""special-defense"": 80}","Nurturing Pokémon","It keeps its eggs warm with heat from fermenting
+leaves. It also uses leaves to make warm wrappings
+for Sewaddle."
+543,"Venipede","[""poison"", ""bug""]",4.00,53.00,"[""speed-boost"", ""swarm"", ""poison-point""]","[""bug""]","{""hp"": 30, ""speed"": 57, ""attack"": 45, ""defense"": 59, ""special-attack"": 30, ""special-defense"": 39}","Centipede Pokémon","Its bite injects a potent poison, enough to paralyze
+large bird Pokémon that try to prey on it."
+544,"Whirlipede","[""poison"", ""bug""]",12.00,585.00,"[""speed-boost"", ""swarm"", ""poison-point""]","[""bug""]","{""hp"": 40, ""speed"": 47, ""attack"": 55, ""defense"": 99, ""special-attack"": 40, ""special-defense"": 79}","Curlipede Pokémon","It is usually motionless, but when attacked,
+it rotates at high speed and then crashes into
+its opponent."
+545,"Scolipede","[""poison"", ""bug""]",25.00,2005.00,"[""speed-boost"", ""swarm"", ""poison-point""]","[""bug""]","{""hp"": 60, ""speed"": 112, ""attack"": 100, ""defense"": 89, ""special-attack"": 55, ""special-defense"": 69}","Megapede Pokémon","With quick movements, it chases down its foes,
+attacking relentlessly with its horns until it prevails."
+546,"Cottonee","[""fairy"", ""grass""]",3.00,6.00,"[""chlorophyll"", ""infiltrator"", ""prankster""]","[""plant"", ""fairy""]","{""hp"": 40, ""speed"": 66, ""attack"": 27, ""defense"": 60, ""special-attack"": 37, ""special-defense"": 50}","Cotton Puff Pokémon","Pillows and beds stuffed with cotton exhaled
+by Cottonee are soft and puffy, light and airy—
+altogether top quality."
+547,"Whimsicott","[""fairy"", ""grass""]",7.00,66.00,"[""chlorophyll"", ""infiltrator"", ""prankster""]","[""plant"", ""fairy""]","{""hp"": 60, ""speed"": 116, ""attack"": 67, ""defense"": 85, ""special-attack"": 77, ""special-defense"": 75}","Windveiled Pokémon","This Pokémon appears, riding upon the wind.
+But if the wind gusts up, it’ll blow the cotton on
+this Pokémon’s head clean off."
+548,"Petilil","[""grass""]",5.00,66.00,"[""leaf-guard"", ""own-tempo"", ""chlorophyll""]","[""plant""]","{""hp"": 45, ""speed"": 30, ""attack"": 35, ""defense"": 50, ""special-attack"": 70, ""special-defense"": 50}","Bulb Pokémon","By pruning the leaves on its head with
+regularity, this Pokémon can be grown into a
+fine plump shape."
+549,"Lilligant","[""grass""]",11.00,163.00,"[""leaf-guard"", ""own-tempo"", ""chlorophyll""]","[""plant""]","{""hp"": 70, ""speed"": 90, ""attack"": 60, ""defense"": 75, ""special-attack"": 110, ""special-defense"": 75}","Flowering Pokémon","As soon as it finds a male to be its partner,
+the beautiful flower on its head darkens,
+droops, and withers away."
+550,"Basculin","[""water""]",10.00,180.00,"[""mold-breaker"", ""adaptability"", ""reckless""]","[""water2""]","{""hp"": 70, ""speed"": 98, ""attack"": 92, ""defense"": 65, ""special-attack"": 80, ""special-defense"": 55}","Hostile Pokémon","Red and blue Basculin usually do not get along,
+but sometimes members of one school mingle with
+the other’s school."
+551,"Sandile","[""dark"", ""ground""]",7.00,152.00,"[""anger-point"", ""moxie"", ""intimidate""]","[""ground""]","{""hp"": 50, ""speed"": 65, ""attack"": 72, ""defense"": 35, ""special-attack"": 35, ""special-defense"": 35}","Desert Croc Pokémon","It conceals itself in the sand and chomps down
+on the legs of any prey that unwarily walk over
+it. Its favorite food is Trapinch."
+552,"Krokorok","[""dark"", ""ground""]",10.00,334.00,"[""anger-point"", ""moxie"", ""intimidate""]","[""ground""]","{""hp"": 60, ""speed"": 74, ""attack"": 82, ""defense"": 45, ""special-attack"": 45, ""special-defense"": 45}","Desert Croc Pokémon","Thanks to the special membrane covering its
+eyes, it can see its surroundings clearly, even in
+the middle of the night."
+553,"Krookodile","[""dark"", ""ground""]",15.00,963.00,"[""anger-point"", ""moxie"", ""intimidate""]","[""ground""]","{""hp"": 95, ""speed"": 92, ""attack"": 117, ""defense"": 80, ""special-attack"": 65, ""special-defense"": 70}","Intimidation Pokémon","After clamping down with its powerful jaws,
+it twists its body around to rip its prey in half."

--- a/database/migrations/2020_01_04_195752_create_pokemon_table.php
+++ b/database/migrations/2020_01_04_195752_create_pokemon_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePokemonTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('pokemon', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('pokemon');
+    }
+}

--- a/database/migrations/2020_01_04_195752_create_pokemon_table.php
+++ b/database/migrations/2020_01_04_195752_create_pokemon_table.php
@@ -14,7 +14,7 @@ class CreatePokemonTable extends Migration
     public function up()
     {
         Schema::create('pokemon', function (Blueprint $table) {
-            $table->bigInteger('id');
+            $table->bigInteger('id')->primary();
             $table->string('name')->unique();
             $table->json('types');
             $table->integer('weight');

--- a/database/migrations/2020_01_04_195752_create_pokemon_table.php
+++ b/database/migrations/2020_01_04_195752_create_pokemon_table.php
@@ -14,7 +14,7 @@ class CreatePokemonTable extends Migration
     public function up()
     {
         Schema::create('pokemon', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->bigInteger('id');
             $table->string('name')->unique();
             $table->json('types');
             $table->integer('weight');

--- a/database/migrations/2020_01_04_195752_create_pokemon_table.php
+++ b/database/migrations/2020_01_04_195752_create_pokemon_table.php
@@ -15,7 +15,17 @@ class CreatePokemonTable extends Migration
     {
         Schema::create('pokemon', function (Blueprint $table) {
             $table->bigIncrements('id');
-            $table->timestamps();
+            $table->string('name')->unique();
+            $table->json('types');
+            $table->integer('weight');
+            $table->integer('height');
+            $table->json('abilities');
+            $table->json('egg_groups');
+            $table->json('stats');
+            $table->string('genus');
+            $table->text('description');
+            $table->timestamp('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->timestamp('updated_at')->default(DB::raw('CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP'));        
         });
     }
 

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        $this->call(Pokemon::class);
     }
 }

--- a/database/seeds/Pokemon.php
+++ b/database/seeds/Pokemon.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use App\Pokemon as PokemonTable;
+
+class Pokemon extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        if (!PokemonTable::all()->first()) {
+
+            $pokemonFile = fopen(base_path('database/data/pokemon.csv'), 'r');
+            if ($pokemonFile !== false) {
+
+                $header = NULL;
+                $data = [];
+
+                while (($row = fgetcsv($pokemonFile, 1000, ',', '"')) !== false) {
+
+                    if (!$header) {
+                        $header = $row;
+                        $header[0] = 'id';
+                    } else {
+                        $data[] = array_combine($header, $row);
+                    }
+                }
+                fclose($pokemonFile);
+
+                PokemonTable::insert($data);
+            }
+        }
+        else {
+            echo "Already Seeded\r\n";
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,3 +14,4 @@ use Illuminate\Http\Request;
 */
 
 Route::get('/pokemon', 'PokemonController@index');
+Route::get('/pokemon/{id}', 'PokemonController@show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,4 @@ use Illuminate\Http\Request;
 |
 */
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
-});
+Route::get('/pokemon', 'PokemonController@index');


### PR DESCRIPTION
Added necessary components for enabling users to retrieve Pokemon data. Components include Pokemon data migration, Pokemon model, Pokemon Routes, Pokemon controller, and Pokemon Seeder. The added routes include /pokemon?page=#&count=# (for retrieving a page of Pokemon based on the provided parameters) and /pokemon/{id} (for retrieving the full record of information on a specific Pokemon. Also added the Pokemon data CVS to the project file structure at app/database/data/pokemon.csv. 